### PR TITLE
Fix error when running ./bin/setup with Rails 5.0.0.1

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -5,7 +5,6 @@ require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
-# require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -22,22 +22,6 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  if config.respond_to?(:assets)
-    # Debug mode disables concatenation and preprocessing of assets.
-    # This option may cause significant delays in view rendering with a large
-    # number of complex assets.
-    config.assets.debug = true
-
-    # Asset digests allow you to set far-future HTTP expiration dates on all assets,
-    # yet still be able to expire them through the digest params.
-    config.assets.digest = true
-
-    # Adds additional error checking when serving assets at runtime.
-    # Checks for improperly declared sprockets dependencies.
-    # Raises helpful error messages.
-    config.assets.raise_runtime_errors = true
-  end
-
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -22,19 +22,21 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
+  if config.respond_to?(:assets)
+    # Debug mode disables concatenation and preprocessing of assets.
+    # This option may cause significant delays in view rendering with a large
+    # number of complex assets.
+    config.assets.debug = true
 
-  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
-  # yet still be able to expire them through the digest params.
-  config.assets.digest = true
+    # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+    # yet still be able to expire them through the digest params.
+    config.assets.digest = true
 
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
+    # Adds additional error checking when serving assets at runtime.
+    # Checks for improperly declared sprockets dependencies.
+    # Raises helpful error messages.
+    config.assets.raise_runtime_errors = true
+  end
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
When trying to set up development environment via `./bin/setup` using a new RVM gemset with Ruby 2.3.0 and Rails 5.0.0.1, the following error occures (caused by [these](https://github.com/palkan/logidze/blob/aaa44bae2c589917ae4455a7b053318f0e9465d9/spec/dummy/config/environments/development.rb#L28-L37) lines):

```
Resolving dependencies...
The Gemfile's dependencies are satisfied
Database 'dummy_development' already exists
Database 'logidze_test' already exists
rake aborted!
NoMethodError: undefined method `assets' for #<Rails::Application::Configuration:0x00000001de17e0>
Did you mean?  asset_host
[ ... STACKTRACE ... ]
```

Steps to reproduce:

1. Create and enable a new RVM gemset:
    
    ````
   $ rvm use 2.3.0  
   $ rvm gemset create logidze-test
   $ rvm gemset use logidze-test
    ````

2. Clone the repo.
3. Run `./bin/setup`.

This patch fixes the error by checking if `Rails::Application::Configuration` responds to `#assets` first. An alternative solution is to uncomment the line `# require 'sprockets/railtie` in `spec/dummy/config/application.rb`.