### PR TITLE
Retain original object's id in `at` method

### DIFF
--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -50,6 +50,9 @@ module Logidze
 
       object_at = dup
       object_at.apply_diff(version, log_data.changes_to(version: version))
+      object_at.id = id
+
+      object_at
     end
 
     # Revert record to the version at specified time (without saving to DB)

--- a/spec/logidze/model_spec.rb
+++ b/spec/logidze/model_spec.rb
@@ -45,6 +45,11 @@ describe Logidze::Model, :db do
       expect(user.age).to eq 10
     end
 
+    it "retains original object's id" do
+      user_old = user.at(time(100))
+      expect(user_old.id).to be_equal(user.id)
+    end
+
     it "handles time as string", :aggregate_failures do
       user_old = user.at("2016-04-12 12:05:50")
       expect(user_old.name).to eq 'test'


### PR DESCRIPTION
This fix will allow to use associations after `at` usage