### PR TITLE
Default version timestamp to "updated_at"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*.rb'
 
-Style/StringLiterals: 
+Style/StringLiterals:
   Enabled: false
 
 Style/SpaceInsideStringInterpolation:
@@ -50,3 +50,14 @@ Rails/Date:
 
 Rails/TimeZone:
   Enabled: false
+
+Style/NumericLiteralPrefix:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: true
+  Exclude:
+    - 'spec/**/*.rb'
+
+Style/DotPosition:
+  EnforcedStyle: leading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## master
+
+- Add `--timestamp_column` option to model migration generator. ([@akxcv][])
+
+- Default version timestamp to timestamp column. ([@akxcv][])
+
 ## 0.4.1 (2017-02-06)
 
 - Add `--path` option to model migration generator. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ By default, Logidze tries to infer the path to the model file from the model nam
 rails generate logidze:model Post --path "app/models/custom/post.rb"
 ```
 
+By default, Logidze tries to get a timestamp for a version from record's `updated_at` field whenever appropriate. If
+your model does not have that column, Logidze will gracefully fall back to `statement_timestamp()`.
+To change the column name or disable this feature completely, you can use the `timestamp_column` option:
+
+```ruby
+# will try to get the timestamp value from `time` column
+rails generate logidze:model Post --timestamp_column time
+# will always set version timestamp to `statement_timestamp()`
+rails generate logidze:model Post --timestamp_column nil # "null" and "false" will also work
+```
+
 ## Troubleshooting
 
 The most common problem is `"permission denied to set parameter "logidze.xxx"` caused by `ALTER DATABASE ...` query.

--- a/lib/generators/logidze/install/templates/migration.rb.erb
+++ b/lib/generators/logidze/install/templates/migration.rb.erb
@@ -23,13 +23,13 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
     <% end %>
 
     execute <<-SQL
-      CREATE OR REPLACE FUNCTION logidze_version(v bigint, data jsonb, blacklist text[] DEFAULT '{}') RETURNS jsonb AS $body$
+      CREATE OR REPLACE FUNCTION logidze_version(v bigint, data jsonb, ts timestamp with time zone, blacklist text[] DEFAULT '{}') RETURNS jsonb AS $body$
         DECLARE
           buf jsonb;
         BEGIN
           buf := jsonb_build_object(
                    'ts',
-                   (extract(epoch from now()) * 1000)::bigint,
+                   (extract(epoch from ts) * 1000)::bigint,
                    'v',
                     v,
                     'c',
@@ -48,7 +48,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
           return json_build_object(
             'v', 1,
             'h', jsonb_build_array(
-                   logidze_version(1, item, blacklist)
+                   logidze_version(1, item, coalesce((item->>'updated_at')::timestamp with time zone, now()), blacklist)
                  )
             );
         END;
@@ -62,7 +62,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
         BEGIN
           res := obj;
           FOREACH key IN ARRAY keys
-          LOOP 
+          LOOP
             res := res - key;
           END LOOP;
           RETURN res;
@@ -93,7 +93,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
             jsonb_set(
               log_data->'h',
               '{1}',
-              merged 
+              merged
             ) - 0
           );
         END;
@@ -111,15 +111,16 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
           iterator integer;
           item record;
           columns_blacklist text[];
+          ts timestamp with time zone;
         BEGIN
           columns_blacklist := TG_ARGV[1];
 
           IF TG_OP = 'INSERT' THEN
 
             NEW.log_data := logidze_snapshot(to_jsonb(NEW.*), columns_blacklist);
-          
+
           ELSIF TG_OP = 'UPDATE' THEN
-          
+
             IF OLD.log_data is NULL OR OLD.log_data = '{}'::jsonb THEN
               NEW.log_data := logidze_snapshot(to_jsonb(NEW.*), columns_blacklist);
               RETURN NEW;
@@ -127,6 +128,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
 
             history_limit := NULLIF(TG_ARGV[0], 'null');
             current_version := (NEW.log_data->>'v')::int;
+            ts := coalesce(NEW.updated_at::timestamp with time zone, now());
 
             IF NEW = OLD THEN
               RETURN NEW;
@@ -158,7 +160,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
             NEW.log_data := jsonb_set(
               NEW.log_data,
               ARRAY['h', size::text],
-              logidze_version(new_v, changes, columns_blacklist),
+              logidze_version(new_v, changes, ts, columns_blacklist),
               true
             );
 
@@ -183,7 +185,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
   def down
     <% unless update? %>
     execute <<-SQL
-      DROP FUNCTION logidze_version(bigint, jsonb, text[]) CASCADE;
+      DROP FUNCTION logidze_version(bigint, jsonb, timestamp with time zone, text[]) CASCADE;
       DROP FUNCTION logidze_compact_history(jsonb) CASCADE;
       DROP FUNCTION logidze_snapshot(jsonb, text[]) CASCADE;
       DROP FUNCTION logidze_logger() CASCADE;

--- a/lib/generators/logidze/install/templates/migration.rb.erb
+++ b/lib/generators/logidze/install/templates/migration.rb.erb
@@ -19,6 +19,8 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
     execute <<-SQL
       DROP FUNCTION IF EXISTS logidze_version(bigint, jsonb);
       DROP FUNCTION IF EXISTS logidze_snapshot(jsonb);
+      DROP FUNCTION IF EXISTS logidze_version(bigint, jsonb, text[]);
+      DROP FUNCTION IF EXISTS logidze_snapshot(jsonb, text[]);
     SQL
     <% end %>
 
@@ -43,12 +45,19 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
       $body$
       LANGUAGE plpgsql;
 
-      CREATE OR REPLACE FUNCTION logidze_snapshot(item jsonb, blacklist text[] DEFAULT '{}') RETURNS jsonb AS $body$
+      CREATE OR REPLACE FUNCTION logidze_snapshot(item jsonb, ts_column text, blacklist text[] DEFAULT '{}') RETURNS jsonb AS $body$
+        DECLARE
+          ts timestamp with time zone;
         BEGIN
+          IF ts_column IS NULL THEN
+            ts := statement_timestamp();
+          ELSE
+            ts := coalesce((item->>ts_column)::timestamp with time zone, statement_timestamp());
+          END IF;
           return json_build_object(
             'v', 1,
             'h', jsonb_build_array(
-                   logidze_version(1, item, coalesce((item->>'updated_at')::timestamp with time zone, now()), blacklist)
+                   logidze_version(1, item, ts, blacklist)
                  )
             );
         END;
@@ -112,23 +121,33 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
           item record;
           columns_blacklist text[];
           ts timestamp with time zone;
+          ts_column text;
         BEGIN
-          columns_blacklist := TG_ARGV[1];
+          ts_column := NULLIF(TG_ARGV[1], 'null');
+          columns_blacklist := TG_ARGV[2];
 
           IF TG_OP = 'INSERT' THEN
 
-            NEW.log_data := logidze_snapshot(to_jsonb(NEW.*), columns_blacklist);
+            NEW.log_data := logidze_snapshot(to_jsonb(NEW.*), ts_column, columns_blacklist);
 
           ELSIF TG_OP = 'UPDATE' THEN
 
             IF OLD.log_data is NULL OR OLD.log_data = '{}'::jsonb THEN
-              NEW.log_data := logidze_snapshot(to_jsonb(NEW.*), columns_blacklist);
+              NEW.log_data := logidze_snapshot(to_jsonb(NEW.*), ts_column, columns_blacklist);
               RETURN NEW;
             END IF;
 
             history_limit := NULLIF(TG_ARGV[0], 'null');
             current_version := (NEW.log_data->>'v')::int;
-            ts := coalesce(NEW.updated_at::timestamp with time zone, now());
+
+            IF ts_column IS NULL THEN
+              ts := statement_timestamp();
+            ELSE
+              ts := (to_jsonb(NEW.*)->>ts_column)::timestamp with time zone;
+              IF ts IS NULL OR ts = (to_jsonb(OLD.*)->>ts_column)::timestamp with time zone THEN
+                ts := statement_timestamp();
+              END IF;
+            END IF;
 
             IF NEW = OLD THEN
               RETURN NEW;
@@ -187,7 +206,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration
     execute <<-SQL
       DROP FUNCTION logidze_version(bigint, jsonb, timestamp with time zone, text[]) CASCADE;
       DROP FUNCTION logidze_compact_history(jsonb) CASCADE;
-      DROP FUNCTION logidze_snapshot(jsonb, text[]) CASCADE;
+      DROP FUNCTION logidze_snapshot(jsonb, text, text[]) CASCADE;
       DROP FUNCTION logidze_logger() CASCADE;
     SQL
     <% end %>

--- a/lib/generators/logidze/model/templates/migration.rb.erb
+++ b/lib/generators/logidze/model/templates/migration.rb.erb
@@ -1,7 +1,7 @@
 class <%= @migration_class_name %> < ActiveRecord::Migration
   require 'logidze/migration'
   include Logidze::Migration
- 
+
   def up
     <% unless only_trigger? %>
     add_column :<%= table_name %>, :log_data, :jsonb

--- a/logidze.gemspec
+++ b/logidze.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", ">= 0.3.8"
   spec.add_development_dependency "ammeter", "~> 1.1.3"
   spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "timecop", "~> 0.8"
 end

--- a/spec/dummy/db/migrate/20160415094739_create_users.rb
+++ b/spec/dummy/db/migrate/20160415094739_create_users.rb
@@ -5,7 +5,7 @@ class CreateUsers < ActiveRecord::Migration
       t.integer :age
       t.boolean :active
       t.jsonb :log_data
-      t.timestamps null: true
+      t.timestamp :time
     end
   end
 end

--- a/spec/dummy/db/migrate/20160415094739_create_users.rb
+++ b/spec/dummy/db/migrate/20160415094739_create_users.rb
@@ -5,7 +5,7 @@ class CreateUsers < ActiveRecord::Migration
       t.integer :age
       t.boolean :active
       t.jsonb :log_data
-      t.timestamps null: false
+      t.timestamps null: true
     end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170228152140) do
+ActiveRecord::Schema.define(version: 20160415194001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "hstore"
 
   create_table "posts", force: :cascade do |t|
     t.string   "title"
@@ -29,8 +28,7 @@ ActiveRecord::Schema.define(version: 20170228152140) do
     t.integer  "age"
     t.boolean  "active"
     t.jsonb    "log_data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "time"
   end
 
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170110144045) do
+ActiveRecord::Schema.define(version: 20170228152140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,8 +29,8 @@ ActiveRecord::Schema.define(version: 20170110144045) do
     t.integer  "age"
     t.boolean  "active"
     t.jsonb    "log_data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end

--- a/spec/integrations/timestamps_spec.rb
+++ b/spec/integrations/timestamps_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require "acceptance_helper"
+
+describe "Logidze timestamps", :db do
+  include_context "cleanup migrations"
+
+  before(:all) do
+    Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
+      successfully "rails generate logidze:install"
+      ActiveRecord::Base.connection_pool.disconnect!
+    end
+  end
+
+  before do
+    Timecop.freeze(Time.at(1_000_000)) do
+      post.update!(rating: 100)
+      user.update!(time: Time.current)
+    end
+    post.reload
+    user.reload
+  end
+
+  let(:post) { Post.create!(updated_at: Time.at(0)).reload }
+  let(:user) { User.create!(time: Time.at(0)).reload }
+
+  context "timestamp_column is not set" do
+    include_context "setup models with timestamp column", nil
+
+    it "uses 'updated_at' column if it exists", :aggregate_failures do
+      expect(post).to use_timestamp(:updated_at)
+      expect(user).to use_statement_timestamp
+    end
+
+    it "sets version timestamp to statement_timestamp() upon insertion" do
+      expect(Post.create!.reload).to use_statement_timestamp
+    end
+
+    it "sets version timestamp to statement_timestamp() if 'updated_at' did not change" do
+      Timecop.freeze(Time.at(2_000_000)) { Post.where(id: post.id).update_all(rating: nil) }
+      expect(post.reload).to use_statement_timestamp
+    end
+  end
+
+  context "timestamp_column is set to 'time'" do
+    include_context "setup models with timestamp column", "time"
+
+    it "uses 'time' column if it exists", :aggregate_failures do
+      expect(post).to use_statement_timestamp
+      expect(user).to use_timestamp(:time)
+    end
+  end
+
+  context "timestamp_column is 'nil'" do
+    # 'nil', 'null' and 'false' are identical
+    include_context "setup models with timestamp column", "nil"
+
+    it "uses statement_timestamp()", :aggregate_failures do
+      expect(user).to use_statement_timestamp
+      expect(user).to use_statement_timestamp
+    end
+  end
+end

--- a/spec/integrations/triggers_spec.rb
+++ b/spec/integrations/triggers_spec.rb
@@ -2,7 +2,7 @@
 require "acceptance_helper"
 
 describe "Logidze triggers", :db do
-  it 'cannot be used with bot whitelist and blacklist options' do
+  it 'cannot be used with both whitelist and blacklist options' do
     Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
       unsuccessfully "rails generate logidze:model post "\
                      "--whitelist=title --blacklist=created_at"
@@ -17,6 +17,7 @@ describe "Logidze triggers", :db do
       Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
         successfully "rails generate logidze:install"
         successfully "rails generate logidze:model post --limit 4 --backfill"
+        successfully "rails generate logidze:model user --limit 4 --backfill --only-trigger"
         successfully "rake db:migrate"
 
         # Close active connections to handle db variables
@@ -30,7 +31,8 @@ describe "Logidze triggers", :db do
 
     after(:all) { @old_post.destroy! }
 
-    let(:params) { { title: 'Triggers', rating: 10, active: false } }
+    let(:post_params) { { title: 'Triggers', rating: 10, active: false } }
+    let(:user_params) { { name: 'Triggers',  age: 20,    active: false } }
 
     describe "backfill" do
       let(:post) { Post.find(@old_post.id) }
@@ -42,11 +44,17 @@ describe "Logidze triggers", :db do
     end
 
     describe "insert" do
-      let(:post) { Post.create!(params).reload }
+      let(:post) { Post.create!(post_params).reload }
+      let(:user) { User.create!(user_params).reload }
 
       it "creates initial version", :aggregate_failures do
         expect(post.log_version).to eq 1
         expect(post.log_size).to eq 1
+      end
+
+      it "sets version timestamp to now()", :aggregate_failures do
+        expect(post.log_data.current_version.time / 1000).to eq(Time.current.to_i)
+        expect(user.log_data.current_version.time / 1000).to eq(Time.current.to_i)
       end
 
       context "when logging is disabled" do
@@ -59,19 +67,27 @@ describe "Logidze triggers", :db do
     end
 
     describe "update" do
-      before(:all) { @post = Post.create! }
-      after(:all) { @post.destroy! }
+      before(:all) do
+        @post = Post.create!
+        @user = User.create!
+      end
+
+      after(:all) do
+        @post.destroy!
+        @user.destroy!
+      end
 
       let(:post) { @post.reload }
+      let(:user) { @user.reload }
 
       it "creates new version", :aggregate_failures do
-        post.update!(params)
+        post.update!(post_params)
         expect(post.reload.log_version).to eq 2
         expect(post.log_size).to eq 2
       end
 
       it "creates several versions", :aggregate_failures do
-        post.update!(params)
+        post.update!(post_params)
         expect(post.log_version).to eq 1
 
         post.update!(rating: 0)
@@ -89,10 +105,20 @@ describe "Logidze triggers", :db do
         expect(post.log_size).to eq 1
       end
 
+      it "sets version timestamp to now() when updated_at column does not exist" do
+        user.update!(user_params)
+        expect(user.reload.log_data.current_version.time / 1000).to eq(Time.current.to_i)
+      end
+
+      it "sets version timestamp to updated_at when updated_at column exists" do
+        Timecop.freeze(Time.at(0)) { post.update!(post_params) }
+        expect(post.reload.log_data.current_version.time / 1000).to eq(Time.at(0).to_i)
+      end
+
       context "logging is disabled" do
         it "doesn't create new version" do
           Logidze.without_logging do
-            post.update!(params)
+            post.update!(post_params)
             expect(post.reload.log_version).to eq 1
             expect(post.log_size).to eq 1
           end
@@ -108,7 +134,7 @@ describe "Logidze triggers", :db do
 
           ignore_exceptions do
             Logidze.without_logging do
-              post.update!(params)
+              post.update!(post_params)
             end
           end
 
@@ -123,7 +149,7 @@ describe "Logidze triggers", :db do
       end
 
       context "log_data is empty" do
-        let(:post) { Post.without_logging { Post.create!(params).reload } }
+        let(:post) { Post.without_logging { Post.create!(post_params).reload } }
 
         it "creates several versions", :aggregate_failures do
           post.update!(rating: 0)
@@ -256,10 +282,10 @@ describe "Logidze triggers", :db do
       Post.instance_variable_set(:@attribute_names, nil)
     end
 
-    let(:params) { { title: 'Triggers', rating: 10, active: false } }
+    let(:post_params) { { title: 'Triggers', rating: 10, active: false } }
 
     describe "insert" do
-      let(:post) { Post.create!(params).reload }
+      let(:post) { Post.create!(post_params).reload }
 
       it "does not log blacklisted columns", :aggregate_failures do
         changes = post.log_data.current_version.changes
@@ -274,7 +300,7 @@ describe "Logidze triggers", :db do
       let(:post) { @post.reload }
 
       it "does not log blacklisted columns", :aggregate_failures do
-        post.update!(params)
+        post.update!(post_params)
         changes = post.log_data.current_version.changes
         expect(changes.keys).to match_array Post.column_names - @blacklist - ['log_data']
       end
@@ -302,10 +328,10 @@ describe "Logidze triggers", :db do
       Post.instance_variable_set(:@attribute_names, nil)
     end
 
-    let(:params) { { title: 'Triggers', rating: 10, active: false } }
+    let(:post_params) { { title: 'Triggers', rating: 10, active: false } }
 
     describe "insert" do
-      let(:post) { Post.create!(params).reload }
+      let(:post) { Post.create!(post_params).reload }
 
       it "logs only whitelisted columns", :aggregate_failures do
         changes = post.log_data.current_version.changes
@@ -320,7 +346,7 @@ describe "Logidze triggers", :db do
       let(:post) { @post.reload }
 
       it "logs only whitelisted columns", :aggregate_failures do
-        post.update!(params)
+        post.update!(post_params)
         changes = post.log_data.current_version.changes
         expect(changes.keys).to match_array @whitelist
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] = "test"
 require "pry-byebug"
 require "ammeter"
 require "database_cleaner"
+require "timecop"
 
 if ENV['COVER']
   require 'simplecov'

--- a/spec/support/acceptance_helpers.rb
+++ b/spec/support/acceptance_helpers.rb
@@ -7,8 +7,8 @@ module Logidze
     end
 
     def unsuccessfully(command)
-      expect(system("RAILS_ENV=test #{command}")).
-        to eq(false), "'#{command}' was successful"
+      expect(system("RAILS_ENV=test #{command}"))
+        .to eq(false), "'#{command}' was successful"
     end
 
     def verify_file_contains(path, statement)

--- a/spec/support/matchers/use_timestamp.rb
+++ b/spec/support/matchers/use_timestamp.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+RSpec::Matchers.define :use_timestamp do |expected|
+  match do |record|
+    record.log_data.current_version.time / 1000 == record.public_send(expected).to_i
+  end
+end
+
+RSpec::Matchers.define :use_statement_timestamp do
+  match do |record|
+    # WARN: dividing by 100 for consistency. Always use Timecop to ensure valid tests.
+    record.log_data.current_version.time / 100_000 == Time.current.to_i / 100
+  end
+end

--- a/spec/support/shared_contexts/setup_models_with_timestamps_column_context.rb
+++ b/spec/support/shared_contexts/setup_models_with_timestamps_column_context.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+shared_context "setup models with timestamp column" do |timestamp_column|
+  include_context "cleanup migrations"
+
+  before(:all) do
+    param = "--timestamp_column #{timestamp_column}" if timestamp_column
+    Dir.chdir("#{File.dirname(__FILE__)}/../../dummy") do
+      # Post has an 'updated_at' column
+      successfully "rails generate logidze:model post #{param}"
+      # User has a 'time' column
+      successfully "rails generate logidze:model user --only-trigger #{param}"
+      successfully "rake db:migrate"
+
+      # Close active connections to handle db variables
+      ActiveRecord::Base.connection_pool.disconnect!
+    end
+  end
+end


### PR DESCRIPTION
Hi! A lot of Rails models have an `updated_at` property which is used for many things. Wouldn't it be more logical and natural to take the value from the `updated_at` column and use it as version's timestamp? If the record's `updated_at` is `nil` or if the table doesn't have this column, version's timestamp will be set to `now()`.

```ruby
# with updated_at column
post = Post.create! # now()
post.update!        # updated_at

# without updated_at column
post = Post.create! # now()
post.update!        # now()
```

Also, it's a big benefit when testing. For example, I might want to use `Timecop.freeze` to freeze time and then update my record (e.x. testing my version decorator). However, `Timecop.freeze` will not affect SQL. If version's timestamp is the same as record's `updated_at`, freezing time becomes trivial.

Let me know what you think about my proposal.
Also submitting a small pull request.