### PR TITLE
Add an option to append versions to the log upon undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add an option to preserve future versions. ([@akxcv][])
+
 - Add `--timestamp_column` option to model migration generator. ([@akxcv][])
 
 - Default version timestamp to timestamp column. ([@akxcv][])

--- a/README.md
+++ b/README.md
@@ -168,7 +168,21 @@ post.redo!
 post.switch_to!(2)
 ```
 
-If you update record after `#undo!` or `#switch_to!` you lose all "future" versions and `#redo!` is no longer possible.
+Normally, if you update record after `#undo!` or `#switch_to!` you lose all "future" versions and `#redo!` is no
+longer possible. However, you can provide an `as_new: true` option to `#undo!` or `#switch_to!`, which will
+create a new version with old data. Caveat: when switching to a newer version, `as_new` will have no effect.
+
+```ruby
+post = Post.create!(title: 'first post') # v1
+post.update!(title: 'new title')         # v2
+post.undo!(as_new: true)                 # v3 (with same attributes as v1)
+```
+
+Alternatively, you can configure Logidze to always default to `as_new: true`.
+
+```ruby
+Logidze.preserve_future = true
+```
 
 ## Track responsibility (aka _whodunnit_)
 

--- a/README.md
+++ b/README.md
@@ -169,20 +169,23 @@ post.switch_to!(2)
 ```
 
 Normally, if you update record after `#undo!` or `#switch_to!` you lose all "future" versions and `#redo!` is no
-longer possible. However, you can provide an `as_new: true` option to `#undo!` or `#switch_to!`, which will
-create a new version with old data. Caveat: when switching to a newer version, `as_new` will have no effect.
+longer possible. However, you can provide an `append: true` option to `#undo!` or `#switch_to!`, which will
+create a new version with old data. Caveat: when switching to a newer version, `append` will have no effect.
 
 ```ruby
 post = Post.create!(title: 'first post') # v1
 post.update!(title: 'new title')         # v2
-post.undo!(as_new: true)                 # v3 (with same attributes as v1)
+post.undo!(append: true)                 # v3 (with same attributes as v1)
 ```
 
-Alternatively, you can configure Logidze to always default to `as_new: true`.
+Note that `redo!` will not work after `undo!(append: true)` because the latter will create a new version
+instead of rolling back to an old one.
+Alternatively, you can configure Logidze to always default to `append: true`.
 
 ```ruby
-Logidze.preserve_future = true
+Logidze.append_on_undo = true
 ```
+
 
 ## Track responsibility (aka _whodunnit_)
 

--- a/lib/logidze.rb
+++ b/lib/logidze.rb
@@ -13,8 +13,8 @@ module Logidze
 
   require 'logidze/engine' if defined?(Rails)
 
-  # Determines if Logidze should append a version to the log after updating an old version.
   class << self
+    # Determines if Logidze should append a version to the log after updating an old version.
     attr_accessor :append_on_undo
   end
 

--- a/lib/logidze.rb
+++ b/lib/logidze.rb
@@ -13,6 +13,8 @@ module Logidze
 
   require 'logidze/engine' if defined?(Rails)
 
+  mattr_accessor :preserve_future
+
   # Temporary disable DB triggers.
   #
   # @example

--- a/lib/logidze.rb
+++ b/lib/logidze.rb
@@ -13,7 +13,10 @@ module Logidze
 
   require 'logidze/engine' if defined?(Rails)
 
-  mattr_accessor :preserve_future
+  # Determines if Logidze should append a version to the log after updating an old version.
+  class << self
+    attr_accessor :append_on_undo
+  end
 
   # Temporary disable DB triggers.
   #

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -96,10 +96,10 @@ module Logidze
 
     # Restore record to the previous version.
     # Return false if no previous version found, otherwise return updated record.
-    def undo!
+    def undo!(as_new: nil)
       version = log_data.previous_version
       return false if version.nil?
-      switch_to!(version.version)
+      switch_to!(version.version, as_new: as_new)
     end
 
     # Restore record to the _future_ version (if `undo!` was applied)
@@ -112,9 +112,16 @@ module Logidze
 
     # Restore record to the specified version.
     # Return false if version is unknown.
-    def switch_to!(version)
-      return false unless at_version!(version)
-      self.class.without_logging { save! }
+    def switch_to!(version, as_new: nil)
+      return false unless at_version(version)
+      as_new = Logidze.preserve_future if as_new.nil?
+
+      if as_new && version < log_version
+        update!(log_data.changes_to(version: version))
+      else
+        at_version!(version)
+        self.class.without_logging { save! }
+      end
     end
 
     protected

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -96,10 +96,10 @@ module Logidze
 
     # Restore record to the previous version.
     # Return false if no previous version found, otherwise return updated record.
-    def undo!(as_new: nil)
+    def undo!(append: Logidze.append_on_undo)
       version = log_data.previous_version
       return false if version.nil?
-      switch_to!(version.version, as_new: as_new)
+      switch_to!(version.version, append: append)
     end
 
     # Restore record to the _future_ version (if `undo!` was applied)
@@ -112,11 +112,10 @@ module Logidze
 
     # Restore record to the specified version.
     # Return false if version is unknown.
-    def switch_to!(version, as_new: nil)
+    def switch_to!(version, append: Logidze.append_on_undo)
       return false unless at_version(version)
-      as_new = Logidze.preserve_future if as_new.nil?
 
-      if as_new && version < log_version
+      if append && version < log_version
         update!(log_data.changes_to(version: version))
       else
         at_version!(version)

--- a/spec/integrations/triggers_spec.rb
+++ b/spec/integrations/triggers_spec.rb
@@ -195,6 +195,15 @@ describe "Logidze triggers", :db do
         expect(post.title).to eq "Triggers"
       end
 
+      it "creates a new version when as_new: true", :focus do
+        post.update!(rating: 5)
+        post.reload.undo!(as_new: true)
+
+        expect(post.reload.log_version).to eq 3
+        expect(post.log_size).to eq 3
+        expect(post.rating).to eq 10
+      end
+
       it "there and back again" do
         post.update!(rating: 5)
 
@@ -203,6 +212,69 @@ describe "Logidze triggers", :db do
         post.undo!
         post.redo!
         expect(post.reload).to eq post_was
+      end
+    end
+
+    describe "switch_to!", :focus do
+      before(:all) { @post = Post.create!(title: 'Triggers', rating: 10) }
+      after(:all) { @post.destroy! }
+
+      let(:post) { @post.reload }
+
+      it "revers to specified version", :aggregate_failures do
+        post.update!(rating: 5)
+        post.reload.switch_to!(1)
+        post.reload
+
+        expect(post.log_version).to eq 1
+        expect(post.log_size).to eq 2
+      end
+
+      it "creates a new version when as_new: true", :aggregate_failures do
+        post.update!(rating: 5)
+        post.reload.switch_to!(1, as_new: true)
+        post.reload
+
+        expect(post.log_version).to eq 3
+        expect(post.log_size).to eq 3
+        expect(post.rating).to eq 10
+      end
+
+      it "reverts to specified version if it's newer than current version", :aggregate_failures do
+        post.update!(rating: 5)
+        post.reload.undo!
+        post.reload
+
+        expect(post.log_version).to eq 1
+        expect(post.log_size).to eq 2
+
+        post.switch_to!(2, as_new: true)
+        post.reload
+
+        expect(post.log_version).to eq 2
+        expect(post.log_size).to eq 2
+      end
+
+      context "as_new is disabled globally" do
+        before(:all) { Logidze.preserve_future = true }
+        after(:all) { Logidze.preserve_future = nil }
+
+        it "creates a new version", :aggregate_failures do
+          post.update!(rating: 5)
+          post.reload.switch_to!(1)
+          post.reload
+          expect(post.log_version).to eq 3
+          expect(post.log_size).to eq 3
+          expect(post.rating).to eq 10
+        end
+
+        it "reverts to specified version when as_new: false", :aggregate_failures do
+          post.update!(rating: 5)
+          post.reload.switch_to!(1, as_new: false)
+          post.reload
+          expect(post.log_version).to eq 1
+          expect(post.log_size).to eq 2
+        end
       end
     end
 

--- a/spec/integrations/triggers_spec.rb
+++ b/spec/integrations/triggers_spec.rb
@@ -195,9 +195,9 @@ describe "Logidze triggers", :db do
         expect(post.title).to eq "Triggers"
       end
 
-      it "creates a new version when as_new: true", :focus do
+      it "creates a new version when append: true" do
         post.update!(rating: 5)
-        post.reload.undo!(as_new: true)
+        post.reload.undo!(append: true)
 
         expect(post.reload.log_version).to eq 3
         expect(post.log_size).to eq 3
@@ -215,7 +215,7 @@ describe "Logidze triggers", :db do
       end
     end
 
-    describe "switch_to!", :focus do
+    describe "switch_to!" do
       before(:all) { @post = Post.create!(title: 'Triggers', rating: 10) }
       after(:all) { @post.destroy! }
 
@@ -230,9 +230,9 @@ describe "Logidze triggers", :db do
         expect(post.log_size).to eq 2
       end
 
-      it "creates a new version when as_new: true", :aggregate_failures do
+      it "creates a new version when append: true", :aggregate_failures do
         post.update!(rating: 5)
-        post.reload.switch_to!(1, as_new: true)
+        post.reload.switch_to!(1, append: true)
         post.reload
 
         expect(post.log_version).to eq 3
@@ -248,16 +248,16 @@ describe "Logidze triggers", :db do
         expect(post.log_version).to eq 1
         expect(post.log_size).to eq 2
 
-        post.switch_to!(2, as_new: true)
+        post.switch_to!(2, append: true)
         post.reload
 
         expect(post.log_version).to eq 2
         expect(post.log_size).to eq 2
       end
 
-      context "as_new is disabled globally" do
-        before(:all) { Logidze.preserve_future = true }
-        after(:all) { Logidze.preserve_future = nil }
+      context "append is disabled globally" do
+        before(:all) { Logidze.append_on_undo = true }
+        after(:all) { Logidze.append_on_undo = nil }
 
         it "creates a new version", :aggregate_failures do
           post.update!(rating: 5)
@@ -268,9 +268,9 @@ describe "Logidze triggers", :db do
           expect(post.rating).to eq 10
         end
 
-        it "reverts to specified version when as_new: false", :aggregate_failures do
+        it "reverts to specified version when append: false", :aggregate_failures do
           post.update!(rating: 5)
-          post.reload.switch_to!(1, as_new: false)
+          post.reload.switch_to!(1, append: false)
           post.reload
           expect(post.log_version).to eq 1
           expect(post.log_size).to eq 2


### PR DESCRIPTION
Our team has encountered a situation where we want Logidze to preserve "future" versions of the record when an older (restored) version is updated. I imagine that this would be a fairly common case, so I propose we add a generator option for that. Example: 

```ruby
# default - future versions are overwritten upon update
rails generate logidze:model Post
post = Post.create!(title: 'first post') # v1
post.update!(title: 'some post')         # v2
post.undo!                               # v1
post.update!(title: 'my post')           # v2
# no-overwrite - future versions are always preserved
rails generate logidze:model Post --no-overwrite
post = Post.create!(title: 'first post') # v1
post.update!(title: 'some post')         # v2
post.undo!                               # v1
post.update!(title: 'my post')           # v3
```

@palkan, what do you think? Should we add some kind of a `delete_version` method which would remove a specific version and then call `logidze_compact_history`?
And while we're at it, should we rename the `timestamp_column` option from #26 to `timestamp-option` for consistency?