### PR TITLE
jsonb diff integration issue

### DIFF
--- a/spec/dummy/db/migrate/20160415194001_create_posts.rb
+++ b/spec/dummy/db/migrate/20160415194001_create_posts.rb
@@ -4,6 +4,7 @@ class CreatePosts < ActiveRecord::Migration
       t.string :title
       t.integer :rating
       t.boolean :active
+      t.jsonb :meta
 
       t.timestamps null: false
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20170220153105) do
     t.string   "title"
     t.integer  "rating"
     t.boolean  "active"
+    t.jsonb    "meta"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/integrations/triggers_spec.rb
+++ b/spec/integrations/triggers_spec.rb
@@ -30,7 +30,7 @@ describe "Logidze triggers", :db do
 
     after(:all) { @old_post.destroy! }
 
-    let(:params) { { title: 'Triggers', rating: 10, active: false, meta: { tags: ['some','tag'] } } }
+    let(:params) { { title: 'Triggers', rating: 10, active: false, meta: { tags: %w(some tag) } } }
 
     describe "backfill" do
       let(:post) { Post.find(@old_post.id) }
@@ -58,17 +58,17 @@ describe "Logidze triggers", :db do
       end
     end
 
-     describe "diff" do
+    describe "diff" do
       let(:post) { Post.create!(params).reload }
 
       it "generates the correct diff", :aggregate_failures do
-        post.update!(meta:{tags:['other']})
-        diff = post.reload.log_data.diff_from version: (post.reload.log_version-1)
+        post.update!(meta: { tags: ['other'] })
+        diff = post.reload.log_data.diff_from version: (post.reload.log_version - 1)
         expected_diff_meta = {
-            "old"=>{"tags"=>["some", "tag"]},
-            "new"=>{"tags" => ["other"]}
+          "old" => { "tags" => %w(some tag) },
+          "new" => { "tags" => %w(other) }
         }
-        expect(diff["meta"]["old"].class).to eq diff["meta"]["new"].class
+        expect(diff["meta"]["new"].class).to eq diff["meta"]["old"].class
         expect(diff["meta"]).to eq expected_diff_meta
       end
     end


### PR DESCRIPTION
when calculating the diff of a model version that has a jsonb column data is incorrectly deserialized 

added failing tests, happy to help but not sure where to start


```
Failures:
  1) Logidze triggers without blacklisting diff generates the correct diff
     Got 2 failures:
     1.1) Failure/Error: expect(diff["meta"]["new"].class).to eq diff["meta"]["old"].class
          
            expected: Hash
                 got: String
          
            (compared using ==)
          
            Diff:
            @@ -1,2 +1,2 @@
            -Hash
            +String
            
          # ./spec/integrations/triggers_spec.rb:71:in `block (4 levels) in <top (required)>'
          # ./spec/acceptance_helper.rb:9:in `block (3 levels) in <top (required)>'
          # ./spec/acceptance_helper.rb:8:in `chdir'
          # ./spec/acceptance_helper.rb:8:in `block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:40:in `block (2 levels) in <top (required)>'
     1.2) Failure/Error: expect(diff["meta"]).to eq expected_diff_meta
          
            expected: {"old"=>{"tags"=>["some", "tag"]}, "new"=>{"tags"=>["other"]}}
                 got: {"old"=>{"tags"=>["some", "tag"]}, "new"=>"{\"tags\": [\"other\"]}"}
          
            (compared using ==)
          
            Diff:
            @@ -1,3 +1,3 @@
            -"new" => {"tags"=>["other"]},
            +"new" => "{\"tags\": [\"other\"]}",
             "old" => {"tags"=>["some", "tag"]},
            
          # ./spec/integrations/triggers_spec.rb:72:in `block (4 levels) in <top (required)>'
          # ./spec/acceptance_helper.rb:9:in `block (3 levels) in <top (required)>'
          # ./spec/acceptance_helper.rb:8:in `chdir'
          # ./spec/acceptance_helper.rb:8:in `block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:40:in `block (2 levels) in <top (required)>'
```