### PR TITLE
Use migration_context, if available (Rails 5.2.0)

### DIFF
--- a/spec/support/shared_contexts/cleanup_files_contexts.rb
+++ b/spec/support/shared_contexts/cleanup_files_contexts.rb
@@ -2,7 +2,12 @@
 shared_context "cleanup migrations" do
   before(:all) { @old_migrations = Dir["spec/dummy/db/migrate/*"] }
   after(:all) do
-    all_versions = ActiveRecord::Migrator.get_all_versions
+    all_versions = if ActiveRecord::Migrator.respond_to?(:get_all_versions)
+                     ActiveRecord::Migrator.get_all_versions
+                   else
+                     ActiveRecord::Base.connection.migration_context.get_all_versions
+                   end
+
     (Dir["spec/dummy/db/migrate/*"] - @old_migrations).each do |path|
       version = path.match(%r{\/(\d+)\_[^\.]+\.rb$})[1]
       if all_versions.include?(version.to_i)


### PR DESCRIPTION
Since Rails 5.2.0 all class methods from `ActiveRecord::Migrator` reside in `ActiveRecord::MigrationContext`, so we should use it to obtain all migration versions