### PR TITLE
Adding debounce time to avoid spamming changelog creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 Usage:
 
-```
+```shell
 # 5000ms
 rails generate logidze:model story --debounce_time=5000
 ```
@@ -31,7 +31,7 @@ The concept is similar to https://underscorejs.org/#debounce
 
 without `debounce_time`
 
-```
+```js
 {
     "h": [
         {
@@ -63,7 +63,7 @@ without `debounce_time`
 
 with `debounce_time` of `10ms`
 
-```
+```js
 {
     "h": [
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## master
 
+## 0.8.0 (2018-10-01)
+
+- [PR [#87](https://github.com/palkan/logidze/pull/87)] Adding debounce time to avoid spamming changelog creation
+
+Usage:
+
+```
+rails generate logidze:model story --debounce_time=5000
+```
+
+You see the following in generated migration
+
+```sql
+CREATE TRIGGER logidze_on_stories
+      BEFORE UPDATE OR INSERT ON stories FOR EACH ROW
+      WHEN (coalesce(#{current_setting('logidze.disabled')}, '') <> 'on')
+      EXECUTE PROCEDURE logidze_logger(null, 'updated_at', null, 5000);
+```
+
+How to upgrade.
+
+Please run `rails generate logidze:install --update` to regenerate stored functions.
+
+This feature checks if several logs came in within a debounce time period then only keep the latest one by merging the latest onto olders.
+
+The concept is similar to https://underscorejs.org/#debounce
+
 ## 0.7.0 (2018-08-29)
 
 - [Fixes [#75](https://github.com/palkan/logidze/issues/70)] Fix association versioning with an optional belongs to ([@ankursethi-uscis][])
@@ -72,7 +99,7 @@ This is a quick fix for a more general problem (see [#59](https://github.com/pal
 
 ## 0.5.1 (2017-06-15)
 
-- _(Fix)_ Drop *all* created functions upon rolling back (https://github.com/palkan/logidze/commit/b8e150cc18b3316a8cf0c78f7117339481fb49c6). ([@vassilevsky][])
+- _(Fix)_ Drop _all_ created functions upon rolling back (https://github.com/palkan/logidze/commit/b8e150cc18b3316a8cf0c78f7117339481fb49c6). ([@vassilevsky][])
 
 ## 0.5.0 (2017-03-28)
 
@@ -123,4 +150,4 @@ This is a quick fix for a more general problem (see [#59](https://github.com/pal
 [@akxcv]: https://github.com/akxcv
 [@vassilevsky]: https://github.com/vassilevsky
 [@ankursethi-uscis]: https://github.com/ankursethi-uscis
-[@DmitryTsepelev]: https://github.com/DmitryTsepelev
+[@dmitrytsepelev]: https://github.com/DmitryTsepelev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## master
 
-## 0.8.0 (2018-10-01)
-
-- [PR [#87](https://github.com/palkan/logidze/pull/87)] Adding debounce time to avoid spamming changelog creation
+- [PR [#87](https://github.com/palkan/logidze/pull/87)] Adding debounce time to avoid spamming changelog creation ([@zocoi][])
 
 Usage:
 
 ```
+# 5000ms
 rails generate logidze:model story --debounce_time=5000
 ```
 
@@ -25,9 +24,67 @@ How to upgrade.
 
 Please run `rails generate logidze:install --update` to regenerate stored functions.
 
-This feature checks if several logs came in within a debounce time period then only keep the latest one by merging the latest onto olders.
+This feature checks if several logs came in within a debounce time period then only keep the latest one
+by merging the latest in previous others.
 
 The concept is similar to https://underscorejs.org/#debounce
+
+without `debounce_time`
+
+```
+{
+    "h": [
+        {
+            "c": {
+                "content": "Content 1"
+            },
+            "v": 1,
+            "ts": 0
+        },
+        {
+            "c": {
+                "content": "content 2",
+                "active": true
+            },
+            "v": 2,
+            "ts": 100
+        },
+        {
+            "c": {
+                "content": "content 3",
+            },
+            "v": 3,
+            "ts": 101
+        }
+    ],
+    "v": 3
+}
+```
+
+with `debounce_time` of `10ms`
+
+```
+{
+    "h": [
+        {
+            "c": {
+                "content": "Content 1"
+            },
+            "v": 1,
+            "ts": 0
+        },
+        {
+            "c": {
+                "content": "content 3",
+                "active": true
+            },
+            "v": 2,
+            "ts": 101
+        }
+    ],
+    "v": 3
+}
+```
 
 ## 0.7.0 (2018-08-29)
 
@@ -151,3 +208,4 @@ This is a quick fix for a more general problem (see [#59](https://github.com/pal
 [@vassilevsky]: https://github.com/vassilevsky
 [@ankursethi-uscis]: https://github.com/ankursethi-uscis
 [@dmitrytsepelev]: https://github.com/DmitryTsepelev
+[@zocoi]: https://github.com/zocoi

--- a/lib/generators/logidze/install/templates/migration.rb.erb
+++ b/lib/generators/logidze/install/templates/migration.rb.erb
@@ -109,6 +109,42 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
       $body$
       LANGUAGE plpgsql;
 
+      CREATE OR REPLACE FUNCTION logidze_merge_recent(log_data jsonb, debounce_time integer) RETURNS jsonb AS $body$
+        DECLARE
+          merged jsonb;
+        BEGIN
+          IF (
+            (
+              (log_data#>'{h,-1,ts}')::text::bigint - (log_data#>'{h,-2,ts}')::text::bigint
+            ) <= debounce_time
+          ) THEN
+            merged := jsonb_build_object(
+              'ts',
+              log_data#>'{h,-1,ts}',
+              'v',
+              log_data#>'{h,-1,v}',
+              'c',
+              (log_data#>'{h,-2,c}') || (log_data#>'{h,-1,c}')
+            );
+
+            IF (log_data#>'{h,-1}' ? 'm') THEN
+              merged := jsonb_set(merged, ARRAY['m'], log_data#>'{h,-1,m}');
+            END IF;
+          END IF;
+
+          return jsonb_set(
+            log_data,
+            '{h}',
+            jsonb_set(
+              log_data->'h',
+              '{-1}',
+              merged
+            ) - -2
+          );
+        END;
+      $body$
+      LANGUAGE plpgsql;
+
       CREATE OR REPLACE FUNCTION logidze_logger() RETURNS TRIGGER AS $body$
         DECLARE
           changes jsonb;
@@ -117,6 +153,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
           new_v integer;
           size integer;
           history_limit integer;
+          debounce_time integer;
           current_version integer;
           merged jsonb;
           iterator integer;
@@ -146,6 +183,8 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
             END IF;
 
             history_limit := NULLIF(TG_ARGV[0], 'null');
+            debounce_time := NULLIF(TG_ARGV[4], 'null');
+
             current_version := (NEW.log_data->>'v')::int;
 
             IF ts_column IS NULL THEN
@@ -205,6 +244,11 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
             IF history_limit IS NOT NULL AND history_limit = size THEN
               NEW.log_data := logidze_compact_history(NEW.log_data);
             END IF;
+
+            IF debounce_time IS NOT NULL THEN
+              NEW.log_data := logidze_merge_recent(NEW.log_data, debounce_time);
+            END IF;
+
           END IF;
 
           return NEW;

--- a/lib/generators/logidze/install/templates/migration.rb.erb
+++ b/lib/generators/logidze/install/templates/migration.rb.erb
@@ -109,42 +109,6 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
       $body$
       LANGUAGE plpgsql;
 
-      CREATE OR REPLACE FUNCTION logidze_merge_recent(log_data jsonb, debounce_time integer) RETURNS jsonb AS $body$
-        DECLARE
-          merged jsonb;
-        BEGIN
-          IF (
-            (
-              (log_data#>'{h,-1,ts}')::text::bigint - (log_data#>'{h,-2,ts}')::text::bigint
-            ) <= debounce_time
-          ) THEN
-            merged := jsonb_build_object(
-              'ts',
-              log_data#>'{h,-1,ts}',
-              'v',
-              log_data#>'{h,-1,v}',
-              'c',
-              (log_data#>'{h,-2,c}') || (log_data#>'{h,-1,c}')
-            );
-
-            IF (log_data#>'{h,-1}' ? 'm') THEN
-              merged := jsonb_set(merged, ARRAY['m'], log_data#>'{h,-1,m}');
-            END IF;
-          END IF;
-
-          return jsonb_set(
-            log_data,
-            '{h}',
-            jsonb_set(
-              log_data->'h',
-              '{-1}',
-              merged
-            ) - -2
-          );
-        END;
-      $body$
-      LANGUAGE plpgsql;
-
       CREATE OR REPLACE FUNCTION logidze_logger() RETURNS TRIGGER AS $body$
         DECLARE
           changes jsonb;
@@ -163,7 +127,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
           ts_column text;
         BEGIN
           ts_column := NULLIF(TG_ARGV[1], 'null');
-          columns_blacklist := TG_ARGV[2];
+          columns_blacklist := COALESCE(NULLIF(TG_ARGV[2], 'null'), '{}');
 
           IF TG_OP = 'INSERT' THEN
             snapshot = logidze_snapshot(to_jsonb(NEW.*), ts_column, columns_blacklist);
@@ -183,7 +147,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
             END IF;
 
             history_limit := NULLIF(TG_ARGV[0], 'null');
-            debounce_time := NULLIF(TG_ARGV[4], 'null');
+            debounce_time := NULLIF(TG_ARGV[3], 'null');
 
             current_version := (NEW.log_data->>'v')::int;
 
@@ -228,6 +192,25 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
               RETURN NEW;
             END IF;
 
+            IF (
+              debounce_time IS NOT NULL AND
+              (version->>'ts')::bigint - (NEW.log_data#>'{h,-1,ts}')::text::bigint <= debounce_time
+            ) THEN
+              -- merge new version with the previous one
+              version := NEW.log_data#>'{h,-1}' || version;
+              version := jsonb_set(
+                version,
+                '{c}',
+                (NEW.log_data#>'{h,-1,c}')::jsonb || (version->>'c')::jsonb
+              );
+              -- remove the previous version from log
+              NEW.log_data := jsonb_set(
+                NEW.log_data,
+                '{h}',
+                (NEW.log_data->'h') - (size - 1)
+              );
+            END IF;
+
             NEW.log_data := jsonb_set(
               NEW.log_data,
               ARRAY['h', size::text],
@@ -244,11 +227,6 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
             IF history_limit IS NOT NULL AND history_limit = size THEN
               NEW.log_data := logidze_compact_history(NEW.log_data);
             END IF;
-
-            IF debounce_time IS NOT NULL THEN
-              NEW.log_data := logidze_merge_recent(NEW.log_data, debounce_time);
-            END IF;
-
           END IF;
 
           return NEW;

--- a/lib/generators/logidze/install/templates/migration.rb.erb
+++ b/lib/generators/logidze/install/templates/migration.rb.erb
@@ -197,12 +197,8 @@ class <%= @migration_class_name %> < ActiveRecord::Migration<%= ActiveRecord::VE
               (version->>'ts')::bigint - (NEW.log_data#>'{h,-1,ts}')::text::bigint <= debounce_time
             ) THEN
               -- merge new version with the previous one
-              version := NEW.log_data#>'{h,-1}' || version;
-              version := jsonb_set(
-                version,
-                '{c}',
-                (NEW.log_data#>'{h,-1,c}')::jsonb || (version->>'c')::jsonb
-              );
+              new_v := (NEW.log_data#>>'{h,-1,v}')::int;
+              version := logidze_version(new_v, (NEW.log_data#>'{h,-1,c}')::jsonb || changes, ts, columns_blacklist);
               -- remove the previous version from log
               NEW.log_data := jsonb_set(
                 NEW.log_data,

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -10,7 +10,8 @@ module Logidze
 
       class_option :limit, type: :numeric, optional: true, desc: "Specify history size limit"
 
-      class_option :debounce_time, type: :numeric, optional: true, desc: "Specify debounce time in millisecond"
+      class_option :debounce_time, type: :numeric, optional: true,
+                                   desc: "Specify debounce time in millisecond"
 
       class_option :backfill, type: :boolean, optional: true,
                               desc: "Add query to backfill existing records history"

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -10,7 +10,7 @@ module Logidze
 
       class_option :limit, type: :numeric, optional: true, desc: "Specify history size limit"
 
-      class_option :debounce_time, type: :numeric, optional: true, desc: "Specify debounce time in which 2 logs will be merged"
+      class_option :debounce_time, type: :numeric, optional: true, desc: "Specify debounce time"
 
       class_option :backfill, type: :boolean, optional: true,
                               desc: "Add query to backfill existing records history"
@@ -89,6 +89,10 @@ module Logidze
           return if %w(nil null false).include?(value)
 
           escape_pgsql_string(value)
+        end
+
+        def debounce_time
+          options[:debounce_time]
         end
 
         def logidze_logger_parameters

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -10,7 +10,7 @@ module Logidze
 
       class_option :limit, type: :numeric, optional: true, desc: "Specify history size limit"
 
-      class_option :debounce_time, type: :numeric, optional: true, desc: "Specify debounce time"
+      class_option :debounce_time, type: :numeric, optional: true, desc: "Specify debounce time in millisecond"
 
       class_option :backfill, type: :boolean, optional: true,
                               desc: "Add query to backfill existing records history"

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -10,6 +10,8 @@ module Logidze
 
       class_option :limit, type: :numeric, optional: true, desc: "Specify history size limit"
 
+      class_option :debounce_time, type: :numeric, optional: true, desc: "Specify debounce time in which 2 logs will be merged"
+
       class_option :backfill, type: :boolean, optional: true,
                               desc: "Add query to backfill existing records history"
 
@@ -90,7 +92,7 @@ module Logidze
         end
 
         def logidze_logger_parameters
-          format_pgsql_args(limit, timestamp_column, columns_blacklist)
+          format_pgsql_args(limit, timestamp_column, columns_blacklist, debounce_time)
         end
 
         def logidze_snapshot_parameters

--- a/lib/logidze/version.rb
+++ b/lib/logidze/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Logidze
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -52,6 +52,15 @@ end
         end
       end
 
+      context "with debounce_time" do
+        let(:args) { ["user", "--debounce_time=5000"] }
+
+        it "creates trigger with debounce_time" do
+          is_expected.to exist
+          is_expected.to contain(/execute procedure logidze_logger\(null, 'updated_at', null, 5000\);/i)
+        end
+      end
+
       context "with columns blacklist" do
         let(:args) { ["user", "--blacklist", "age", "active"] }
 

--- a/spec/integrations/triggers_spec.rb
+++ b/spec/integrations/triggers_spec.rb
@@ -513,7 +513,7 @@ describe "Logidze triggers", :db do
       Timecop.freeze(Time.at(1_000_001)) do
         post.update!(rating: 100)
       end
-      expect(post.reload.log_version).to eq 2
+      expect(post.reload.log_version).to eq 1
       expect(post.log_size).to eq 1
       expect(post.log_data.versions.last.changes)
         .to include("title" => "Triggers", "rating" => 100)
@@ -532,7 +532,7 @@ describe "Logidze triggers", :db do
       Timecop.freeze(Time.at(1_000_101)) do
         post.update!(title: "Debounced")
       end
-      expect(post.reload.log_version).to eq 3
+      expect(post.reload.log_version).to eq 2
       expect(post.log_size).to eq 2
       expect(post.log_data.versions.last.changes)
         .to include("title" => "Debounced", "rating" => 100)
@@ -541,7 +541,7 @@ describe "Logidze triggers", :db do
         post.update!(active: true)
       end
 
-      expect(post.reload.log_version).to eq 4
+      expect(post.reload.log_version).to eq 3
       expect(post.log_size).to eq 3
     end
   end

--- a/spec/integrations/triggers_spec.rb
+++ b/spec/integrations/triggers_spec.rb
@@ -472,4 +472,49 @@ describe "Logidze triggers", :db do
       expect(changes2.keys).to match_array Post.column_names - %w(updated_at log_data)
     end
   end
+
+  describe "with debounce_time" do
+    include_context "cleanup migrations"
+
+    before(:all) do
+      Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
+        successfully "rails generate logidze:install"
+        successfully "rails generate logidze:model post --debounce_time=5000"
+        successfully "rake db:migrate"
+
+        # Close active connections to handle db variables
+        ActiveRecord::Base.connection_pool.disconnect!
+      end
+
+      Post.reset_column_information
+      # For Rails 4
+      Post.instance_variable_set(:@attribute_names, nil)
+    end
+
+    it "stores limited number of logs", :aggregate_failures do
+      post = nil
+      Timecop.freeze(Time.at(1_000_000)) do
+        post = Post.create!(title: 'Triggers', rating: 10)
+      end
+      Timecop.freeze(Time.at(1_000_100)) do
+        post.update!(rating: 100)
+      end
+      expect(post.reload.log_version).to eq 2
+      expect(post.log_size).to eq 2
+      Timecop.freeze(Time.at(1_000_101)) do
+        post.update!(title: "Debounced")
+      end
+      expect(post.reload.log_version).to eq 3
+      expect(post.log_size).to eq 2
+      expect(post.log_data.versions.last.changes)
+        .to include("title" => "Debounced", "rating" => 100)
+
+      Timecop.freeze(Time.at(1_000_120)) do
+        post.update!(active: true)
+      end
+
+      expect(post.reload.log_version).to eq 4
+      expect(post.log_size).to eq 3
+    end
+  end
 end

--- a/spec/integrations/triggers_spec.rb
+++ b/spec/integrations/triggers_spec.rb
@@ -491,7 +491,35 @@ describe "Logidze triggers", :db do
       Post.instance_variable_set(:@attribute_names, nil)
     end
 
-    it "stores limited number of logs", :aggregate_failures do
+    it 'does not merge the logs outside debounce_time' do
+      post = nil
+      Timecop.freeze(Time.at(1_000_000)) do
+        post = Post.create!(title: 'Triggers', rating: 10)
+      end
+      Timecop.freeze(Time.at(1_000_100)) do
+        post.update!(rating: 100)
+      end
+      expect(post.reload.log_version).to eq 2
+      expect(post.log_size).to eq 2
+      expect(post.log_data.versions.last.changes)
+        .to_not include("title" => 'Triggers')
+    end
+
+    it 'merges the logs within debounce_time' do
+      post = nil
+      Timecop.freeze(Time.at(1_000_000)) do
+        post = Post.create!(title: 'Triggers', rating: 10)
+      end
+      Timecop.freeze(Time.at(1_000_001)) do
+        post.update!(rating: 100)
+      end
+      expect(post.reload.log_version).to eq 2
+      expect(post.log_size).to eq 1
+      expect(post.log_data.versions.last.changes)
+        .to include("title" => "Triggers", "rating" => 100)
+    end
+
+    it "merges the logs within timeline", :aggregate_failures do
       post = nil
       Timecop.freeze(Time.at(1_000_000)) do
         post = Post.create!(title: 'Triggers', rating: 10)


### PR DESCRIPTION
Usecase: We have a `Blog` model which get frequent minor updates for the `content` column as the editor keeps typing with the CMS autosave feature (every 5s) and we don't want to create log to capture tiny changes. The content text could be big so we need to save space. I came up with a concept similar to https://underscorejs.org/#debounce. The idea is that if the several logs came in within a time period, we only keep the latest one and discard the rest. 

```
{
    "h": [
        {
            "c": {
                "content": "Content 1"
            },
            "v": 1,
            "ts": 0
        },
        {
            "c": {
                "content": "content 2"
            },
            "v": 2,
            "ts": 100
        },
        {
            "c": {
                "content": "content 3"
            },
            "v": 3,
            "ts": 101
        }
    ],
    "v": 3
}
```

becomes

```
{
    "h": [
        {
            "c": {
                "content": "Content 1"
            },
            "v": 1,
            "ts": 0
        },
        {
            "c": {
                "content": "content 3"
            },
            "v": 3,
            "ts": 101
        }
    ],
    "v": 3
}
```

Notice that version 2 is gone

Please give feedback and help optimize the sql part.

Right now the code doesn't care if columns are edited by different `responsible_id`s but that could be easily added.