### PR TITLE
Return 0 for log size when log_data is nil

### DIFF
--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -25,7 +25,7 @@ module Logidze
         attribute :log_data, Logidze::History::Type.new
       end
 
-      delegate :version, :size, to: :log_data, prefix: "log"
+      delegate :version, to: :log_data, prefix: "log"
     end
 
     module ClassMethods # :nodoc:
@@ -194,6 +194,12 @@ module Logidze
       association
     end
     # rubocop: enable Metrics/MethodLength
+
+    def log_size
+      return 0 unless log_data
+
+      log_data.size
+    end
 
     protected
 

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -196,9 +196,7 @@ module Logidze
     # rubocop: enable Metrics/MethodLength
 
     def log_size
-      return 0 unless log_data
-
-      log_data.size
+      log_data&.size || 0
     end
 
     protected

--- a/spec/logidze/model_spec.rb
+++ b/spec/logidze/model_spec.rb
@@ -557,4 +557,18 @@ describe Logidze::Model, :db do
       end
     end
   end
+
+  describe '#log_size' do
+    subject { user.log_size }
+
+    it { is_expected.to eq(user.log_data.size) }
+
+    context 'when model created within a without_logging block' do
+      let(:user) { User.create!(name: 'test') }
+
+      before { Logidze.without_logging { user } }
+
+      it { is_expected.to be_zero }
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/palkan/logidze/issues/92

log_size method returns 0 when log_data is nil