### PR TITLE
Add API to nullify log_data column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Reset the history for a record (or records):
 record.reset_log_data
 
 # for relation
-User.where(...).reset_log_data
+User.where(active: true).reset_log_data
 ```
 
 ## 0.9.0 (2018-11-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## master
 
+- PR [#110](https://github.com/palkan/logidze/pull/110) Add `reset_log_data` API to nullify log_data column ([@Arkweid][])
+
+Usage:
+
+Reset the history for a record (or records):
+
+```ruby
+# for single record
+record.reset_log_data
+
+# for relation
+User.where(...).reset_log_data
+```
+
 ## 0.9.0 (2018-11-28)
 
 - PR [#98](https://github.com/palkan/logidze/pull/98) Add `:ignore_log_data` option to `#has_logidze` ([@dmitrytsepelev][])

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Reset the history for a record (or records):
 record.reset_log_data
 
 # for relation
-User.where(...).reset_log_data
+User.where(active: true).reset_log_data
 ```
 
 ## Log format

--- a/README.md
+++ b/README.md
@@ -304,6 +304,18 @@ Logidze.without_logging { Post.update_all(seen: true) }
 Post.without_logging { Post.update_all(seen: true) }
 ```
 
+## Reset log
+
+Reset the history for a record (or records):
+
+```ruby
+# for single record
+record.reset_log_data
+
+# for relation
+User.where(...).reset_log_data
+```
+
 ## Log format
 
 The `log_data` column has the following format:

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -53,6 +53,11 @@ module Logidze
         true
       end
       # rubocop: enable Naming/PredicateName
+
+      # Nullify log_data column for a association
+      def reset_log_data
+        without_logging { update_all(log_data: nil) }
+      end
     end
 
     # Use this to convert Ruby time to milliseconds
@@ -202,6 +207,11 @@ module Logidze
     # Loads log_data field from the database, stores to the attributes hash and returns it
     def reload_log_data
       self.log_data = self.class.where(self.class.primary_key => id).pluck(:log_data).first
+    end
+
+    # Nullify log_data column for a single record
+    def reset_log_data
+      self.class.without_logging { update_column(:log_data, nil) }
     end
 
     protected

--- a/spec/logidze/model_spec.rb
+++ b/spec/logidze/model_spec.rb
@@ -578,4 +578,30 @@ describe Logidze::Model, :db do
       it { is_expected.to be_zero }
     end
   end
+
+  describe '.reset_log_data' do
+    let!(:user2) { user.dup.tap(&:save!) }
+    let!(:user3) { user.dup.tap(&:save!) }
+
+    before { User.limit(2).reset_log_data }
+
+    it 'nullify log_data column for a association' do
+      expect(user.reload.log_size).to be_zero
+      expect(user2.reload.log_size).to be_zero
+    end
+
+    it 'not affect other model records' do
+      expect(user3.reload.log_size).to eq 5
+    end
+  end
+
+  describe '#reset_log_data' do
+    subject { user.log_size }
+
+    before { user.reset_log_data }
+
+    it 'nullify log_data column for a single record' do
+      is_expected.to be_zero
+    end
+  end
 end


### PR DESCRIPTION
#108 This commit add class method .reset_log_data for nullify
association and instance method #reset_log_data for nullify
single record. 
