### PR TITLE
Global configuration for :ignore_log_data option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## master
 
+- PR [#111](https://github.com/palkan/logidze/pull/111) Global configuration for `:ignore_log_data` option ([@dmitrytsepelev][])
+
+Now it's possible to avoid loading `log_data` from the DB by default with
+
+```ruby
+Logidze.ignore_log_data_by_default = true
+```
+
+In cases when `ignore_log_data: false` is explicitly passed to the `ignore_log_data` the default setting is being overriden. Also, it's possible to change it inside the block:
+
+```ruby
+Logidze.with_log_data do
+  Post.find(params[:id]).log_data
+end
+```
+
 - PR [#110](https://github.com/palkan/logidze/pull/110) Add `reset_log_data` API to nullify log_data column ([@Arkweid][])
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -227,7 +227,21 @@ class User < ActiveRecord::Base
 end
 ```
 
-After that, each time you use `User.all` (or any other relation method) `log_data` won't be loaded from the DB.
+If you want Logidze to always behave this way - you can set up a global configuration option:
+
+```ruby
+Rails.application.config.logidze.ignore_log_data_by_default = true
+```
+
+However, you can override it by explicitly passing `ignore_log_data: false` to the `ignore_log_data`. Also, it's possible to change it temporary inside the block:
+
+```ruby
+Logidze.with_log_data do
+  Post.find(params[:id]).log_data
+end
+```
+
+When `ignore_log_data` is turned on, each time you use `User.all` (or any other relation method) `log_data` won't be loaded from the DB.
 
 The chart below shows the difference in PG query time before and after turning `ignore_log_data` on. (Special thanks to [@aderyabin](https://github.com/aderyabin) for sharing it.)
 

--- a/lib/logidze/has_logidze.rb
+++ b/lib/logidze/has_logidze.rb
@@ -10,9 +10,19 @@ module Logidze
       # Include methods to work with history.
       #
       # rubocop:disable Naming/PredicateName
-      def has_logidze(ignore_log_data: false)
+      def has_logidze(ignore_log_data: nil)
         include Logidze::Model
-        include Logidze::IgnoreLogData if ignore_log_data
+        include Logidze::IgnoreLogData
+
+        @ignore_log_data = ignore_log_data
+      end
+
+      def ignores_log_data?
+        if @ignore_log_data.nil? && Logidze.ignore_log_data_by_default
+          !Logidze.force_load_log_data
+        else
+          @ignore_log_data
+        end
       end
     end
   end

--- a/lib/logidze/ignore_log_data.rb
+++ b/lib/logidze/ignore_log_data.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Logidze
-  # Add `has_logidze` method to AR::Base
-  module IgnoreLogData
+  module IgnoreLogData # :nodoc:
     extend ActiveSupport::Concern
 
     included do
@@ -16,14 +15,19 @@ module Logidze
 
         require "logidze/ignore_log_data/missing_attribute_patch"
         include MissingAttributePatch
+
+        require "logidze/ignore_log_data/default_scope_patch"
+        include DefaultScopePatch
       end
 
       self.ignored_columns += ["log_data"]
+
+      scope :with_log_data, -> { select(column_names + ["log_data"]) }
     end
 
-    module ClassMethods # :nodoc:
-      def with_log_data
-        select(column_names + ["log_data"])
+    class_methods do
+      def self.default_scope
+        ignores_log_data? ? super : super.with_log_data
       end
     end
   end

--- a/lib/logidze/ignore_log_data.rb
+++ b/lib/logidze/ignore_log_data.rb
@@ -24,7 +24,13 @@ module Logidze
 
       self.ignored_columns += ["log_data"]
 
-      scope :with_log_data, -> { select(column_names + ["log_data"]) }
+      scope :with_log_data, lambda {
+        if ignored_columns == ["log_data"]
+          select("*")
+        else
+          select(column_names + ["log_data"])
+        end
+      }
     end
 
     module ClassMethods # :nodoc:

--- a/lib/logidze/ignore_log_data/association.rb
+++ b/lib/logidze/ignore_log_data/association.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Logidze
+  module IgnoreLogData
+    module Association # :nodoc:
+      def target_scope
+        super.with_log_data
+      end
+    end
+  end
+end

--- a/lib/logidze/ignore_log_data/default_scope_patch.rb
+++ b/lib/logidze/ignore_log_data/default_scope_patch.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Logidze
+  module IgnoreLogData
+    # Since Rails caches ignored_columns, we have to patch .column_names and
+    # .unscoped methods to make conditional log_data loading possible
+    module DefaultScopePatch
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def column_names
+          ignores_log_data? ? super : super + ["log_data"]
+        end
+
+        def unscoped
+          if ignores_log_data?
+            super
+          else
+            block_given? ? with_log_data.scoping { yield } : with_log_data
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/logidze/ignore_log_data/ignored_columns.rb
+++ b/lib/logidze/ignore_log_data/ignored_columns.rb
@@ -16,7 +16,7 @@ module Logidze
         private
 
         def build_select(arel)
-          if select_values.blank? && klass.ignored_columns.any?
+          if select_values.blank? && klass.ignored_columns.any? && ignores_log_data?
             arel.project(*arel_columns(klass.column_names - klass.ignored_columns))
           else
             super

--- a/lib/logidze/ignore_log_data/missing_attribute_patch.rb
+++ b/lib/logidze/ignore_log_data/missing_attribute_patch.rb
@@ -7,7 +7,9 @@ module Logidze
     # from Rails 4 - raise ActiveModel::MissingAttributeError
     module MissingAttributePatch
       def log_data
-        raise ActiveModel::MissingAttributeError if attributes["log_data"].nil?
+        if self.class.ignores_log_data? && attributes["log_data"].nil?
+          raise ActiveModel::MissingAttributeError
+        end
 
         super
       end

--- a/spec/dummy/app/models/always_logged_post.rb
+++ b/spec/dummy/app/models/always_logged_post.rb
@@ -1,0 +1,5 @@
+class AlwaysLoggedPost < ActiveRecord::Base
+  has_logidze ignore_log_data: false
+
+  self.table_name = "posts"
+end

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -1,4 +1,4 @@
 class Comment < ActiveRecord::Base
-  has_logidze
+  has_logidze ignore_log_data: false
   belongs_to :article
 end

--- a/spec/dummy/app/models/not_logged_post.rb
+++ b/spec/dummy/app/models/not_logged_post.rb
@@ -1,3 +1,7 @@
-class NotLoggedPost < Post
+class NotLoggedPost < ActiveRecord::Base
   has_logidze ignore_log_data: true
+
+  self.table_name = "posts"
+
+  belongs_to :user
 end

--- a/spec/dummy/app/models/not_logged_post.rb
+++ b/spec/dummy/app/models/not_logged_post.rb
@@ -4,4 +4,5 @@ class NotLoggedPost < ActiveRecord::Base
   self.table_name = "posts"
 
   belongs_to :user
+  has_many :comments, class_name: "NotLoggedPostComment", foreign_key: :post_id
 end

--- a/spec/dummy/app/models/not_logged_post_comment.rb
+++ b/spec/dummy/app/models/not_logged_post_comment.rb
@@ -1,0 +1,5 @@
+class NotLoggedPostComment < ActiveRecord::Base
+  has_logidze ignore_log_data: true
+
+  self.table_name = "post_comments"
+end

--- a/spec/dummy/db/migrate/20180315522153_create_post_comments.rb
+++ b/spec/dummy/db/migrate/20180315522153_create_post_comments.rb
@@ -1,0 +1,10 @@
+class CreatePostComments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :post_comments do |t|
+      t.text :content
+      t.references :post, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2017_02_20_153105) do
+ActiveRecord::Schema.define(version: 2018_03_15_522153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,14 @@ ActiveRecord::Schema.define(version: 2017_02_20_153105) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["article_id"], name: "index_comments_on_article_id"
+  end
+
+  create_table "post_comments", id: :serial, force: :cascade do |t|
+    t.text "content"
+    t.integer "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_post_comments_on_post_id"
   end
 
   create_table "posts", id: :serial, force: :cascade do |t|
@@ -58,4 +66,5 @@ ActiveRecord::Schema.define(version: 2017_02_20_153105) do
 
   add_foreign_key "articles", "users"
   add_foreign_key "comments", "articles"
+  add_foreign_key "post_comments", "posts"
 end

--- a/spec/integrations/ignore_log_data_spec.rb
+++ b/spec/integrations/ignore_log_data_spec.rb
@@ -9,6 +9,7 @@ describe Logidze::IgnoreLogData, :db do
     Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
       successfully "rails generate logidze:install"
       successfully "rails generate logidze:model post"
+      successfully "rails generate logidze:model post_comment"
       successfully "rake db:migrate"
 
       # Close active connections to handle db variables
@@ -100,6 +101,19 @@ describe Logidze::IgnoreLogData, :db do
 
         include_examples "test raises error when #log_data is called"
         include_context "test #reload_log_data"
+      end
+    end
+
+    describe "associations" do
+      context "when owner has loaded log_data" do
+        before { post.comments.create(content: 'New comment') }
+
+        subject do
+          loaded = NotLoggedPost.with_log_data.find(post.id)
+          loaded.comments[0]
+        end
+
+        include_examples "test loads #log_data"
       end
     end
   end


### PR DESCRIPTION
This is the implementation of #109. The idea is that we store a list of models that allow overriding the global setting (i.e. where `:ignore_log_data` is not specified) and when global setting is changed - we start or stop ignoring the `log_data` column.