### PR TITLE
Add support for setting meta without transaction block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
+
 # Change log
 
 ## master (unreleased)
+- PR [#143](https://github.com/palkan/logidze/pull/143) Add `:transactional` option to `#with_meta` and `#with_responsible` ([@oleg-kiviljov][])
+
+Now it's possible to set meta and responsible without wrapping the block into a DB transaction. For backward compatibility  `:transactional` option by default is set to `true`.
+
+Usage:
+
+```ruby
+Logidze.with_meta({ip: request.ip}, transactional: false) do
+  post.save!
+end
+```
+or
+```ruby
+Logidze.with_responsible(user.id, transactional: false) do
+  post.save!
+end
+```
 
 ## 0.11.0 (2019-08-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,3 +302,4 @@ This is a quick fix for a more general problem (see [#59](https://github.com/pal
 [@dmitrytsepelev]: https://github.com/DmitryTsepelev
 [@zocoi]: https://github.com/zocoi
 [@duderman]: https://github.com/duderman
+[@oleg-kiviljov]: https://github.com/oleg-kiviljov

--- a/README.md
+++ b/README.md
@@ -261,7 +261,13 @@ end
 
 Meta expects a hash to be passed so you won't need to encode and decode JSON manually.
 
-**NOTE**: `.with_meta` wraps the block into a DB transaction (see https://github.com/palkan/logidze/issues/136).
+By default `.with_meta` wraps the block into a DB transaction. That could lead to an unexpected behavior, especially, when using `.with_meta` within an around_action. To avoid wrapping the block into a DB transaction use `transactional: false` option.
+
+```ruby
+Logidze.with_meta({ip: request.ip}, transactional: false) do
+  post.save!
+end
+```
 
 ## Track responsibility (aka _whodunnit_)
 
@@ -306,8 +312,13 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-**NOTE**: `.with_responsible` wraps the block into a DB transaction (see https://github.com/palkan/logidze/issues/136).
+By default `.with_responsible` wraps the block into a DB transaction. That could lead to an unexpected behavior, especially, when using `.with_responsible` within an around_action. To avoid wrapping the block into a DB transaction use `transactional: false` option.
 
+```ruby
+Logidze.with_responsible(user.id, transactional: false) do
+  post.save!
+end
+```
 ## Disable logging temporary
 
 If you want to make update without logging (e.g., mass update), you can turn it off the following way:

--- a/lib/logidze/meta.rb
+++ b/lib/logidze/meta.rb
@@ -3,18 +3,20 @@
 module Logidze # :nodoc:
   # Provide methods to attach meta information
   module Meta
-    def with_meta(meta, &block)
-      MetaTransaction.wrap_with(meta, &block)
+    def with_meta(meta, transactional: true, &block)
+      return MetaWithTransaction.wrap_with(meta, &block) if transactional
+
+      MetaWithoutTransaction.wrap_with(meta, &block)
     end
 
-    def with_responsible(responsible_id, &block)
+    def with_responsible(responsible_id, transactional: true, &block)
       return yield if responsible_id.nil?
 
       meta = {Logidze::History::Version::META_RESPONSIBLE => responsible_id}
-      with_meta(meta, &block)
+      with_meta(meta, transactional: transactional, &block)
     end
 
-    class MetaTransaction # :nodoc:
+    class MetaWrapper # :nodoc:
       def self.wrap_with(meta, &block)
         new(meta, &block).perform
       end
@@ -28,6 +30,21 @@ module Logidze # :nodoc:
         @block = block
       end
 
+      def current_meta
+        meta_stack.reduce(:merge) || {}
+      end
+
+      def meta_stack
+        Thread.current[:meta] ||= []
+        Thread.current[:meta]
+      end
+
+      def encode_meta(value)
+        connection.quote(ActiveSupport::JSON.encode(value))
+      end
+    end
+
+    class MetaWithTransaction < MetaWrapper # :nodoc:
       def perform
         return if block.nil?
         return block.call if meta.nil?
@@ -36,6 +53,18 @@ module Logidze # :nodoc:
       end
 
       private
+
+      def pg_set_meta_param(value)
+        connection.execute("SET LOCAL logidze.meta = #{encode_meta(value)};")
+      end
+
+      def pg_reset_meta_param(prev_meta)
+        if prev_meta.empty?
+          connection.execute("SET LOCAL logidze.meta TO DEFAULT;")
+        else
+          pg_set_meta_param(prev_meta)
+        end
+      end
 
       def call_block_in_meta_context
         prev_meta = current_meta
@@ -50,30 +79,46 @@ module Logidze # :nodoc:
       ensure
         meta_stack.pop
       end
+    end
 
-      def current_meta
-        meta_stack.reduce(:merge) || {}
+    class MetaWithoutTransaction < MetaWrapper # :nodoc:
+      def perform
+        raise ArgumentError, "Block must be given" unless block
+
+        call_block_in_meta_context
       end
 
-      def meta_stack
-        Thread.current[:meta] ||= []
-        Thread.current[:meta]
-      end
+      private
 
       def pg_set_meta_param(value)
-        encoded_meta = connection.quote(ActiveSupport::JSON.encode(value))
-        connection.execute("SET LOCAL logidze.meta = #{encoded_meta};")
+        connection.execute("SET logidze.meta = #{encode_meta(value)};")
       end
 
       def pg_reset_meta_param(prev_meta)
         if prev_meta.empty?
-          connection.execute("SET LOCAL logidze.meta TO DEFAULT;")
+          connection.execute("SET logidze.meta TO DEFAULT;")
         else
           pg_set_meta_param(prev_meta)
         end
       end
+
+      def call_block_in_meta_context
+        prev_meta = current_meta
+
+        meta_stack.push(meta)
+
+        pg_set_meta_param(current_meta)
+        result = block.call
+
+        result
+      ensure
+        pg_reset_meta_param(prev_meta)
+        meta_stack.pop
+      end
     end
 
-    private_constant :MetaTransaction
+    private_constant :MetaWrapper
+    private_constant :MetaWithTransaction
+    private_constant :MetaWithoutTransaction
   end
 end

--- a/lib/logidze/meta.rb
+++ b/lib/logidze/meta.rb
@@ -4,9 +4,8 @@ module Logidze # :nodoc:
   # Provide methods to attach meta information
   module Meta
     def with_meta(meta, transactional: true, &block)
-      return MetaWithTransaction.wrap_with(meta, &block) if transactional
-
-      MetaWithoutTransaction.wrap_with(meta, &block)
+      wrapper = transactional ? MetaWithTransaction : MetaWithoutTransaction
+      wrapper.wrap_with(meta, &block)
     end
 
     def with_responsible(responsible_id, transactional: true, &block)

--- a/lib/logidze/meta.rb
+++ b/lib/logidze/meta.rb
@@ -30,7 +30,7 @@ module Logidze # :nodoc:
       end
 
       def perform
-        return if block.nil?
+        raise ArgumentError, 'Block must be given' unless block
         return block.call if meta.nil?
 
         call_block_in_meta_context

--- a/lib/logidze/meta.rb
+++ b/lib/logidze/meta.rb
@@ -30,7 +30,7 @@ module Logidze # :nodoc:
       end
 
       def perform
-        raise ArgumentError, 'Block must be given' unless block
+        raise ArgumentError, "Block must be given" unless block
         return block.call if meta.nil?
 
         call_block_in_meta_context

--- a/spec/integrations/meta_spec.rb
+++ b/spec/integrations/meta_spec.rb
@@ -213,6 +213,28 @@ describe "Logidze meta", :db do
         expect(subject.at_version(3).meta).to eq meta2
       end
     end
+
+    context "when transactional:false" do
+      it "resets meta setting after block finishes" do
+        # subject is a newly created user
+        Logidze.with_meta(meta, transactional: false) do
+          expect(subject.reload.meta).to eq meta
+        end
+
+        # create another one and check that meta is nil here
+        expect(User.create!(name: "test", age: 10, active: false).reload.meta).to be_nil
+      end
+
+      it "recovers after exception" do
+        ignore_exceptions do
+          Logidze.with_meta(meta, transactional: false) do
+            CustomUser.create!
+          end
+        end
+
+        expect(subject.reload.meta).to be_nil
+      end
+    end
   end
 
   describe ".with_responsible" do


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

### What is the purpose of this pull request?
Adds support for setting meta without the database transaction block.
### What changes did you make? (overview)
I've added the possibility to specify if meta information should be set within the transaction block or not. For this I have added the optional argument to the .with_meta method and split the MetaTransaction class into 3 separate classes, MetaWrapper, MetaWithTransaction and MetaWithoutTransaction. 
### Is there anything you'd like reviewers to focus on?
...
### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation (Readme)
