### PR TITLE
Add ability to set responsible for the whole lifetime of the connection

### DIFF
--- a/lib/logidze/meta.rb
+++ b/lib/logidze/meta.rb
@@ -15,6 +15,17 @@ module Logidze # :nodoc:
       with_meta(meta, transactional: transactional, &block)
     end
 
+    def with_responsible!(responsible_id)
+      return if responsible_id.nil?
+
+      meta = {Logidze::History::Version::META_RESPONSIBLE => responsible_id}
+      PermanentMetaWithTransaction.wrap_with(meta, &proc {})
+    end
+
+    def clear_responsible!
+      PermanentMetaWithTransaction.wrap_with({}, &proc {})
+    end
+
     class MetaWrapper # :nodoc:
       def self.wrap_with(meta, &block)
         new(meta, &block).perform
@@ -85,6 +96,12 @@ module Logidze # :nodoc:
       def pg_clear_meta_param
         connection.execute("SET LOCAL logidze.meta TO DEFAULT;")
       end
+    end
+
+    class PermanentMetaWithTransaction < MetaWithTransaction # :nodoc:
+      private
+
+      def pg_clear_meta_param; end
     end
 
     class MetaWithoutTransaction < MetaWrapper # :nodoc:


### PR DESCRIPTION
### What is the purpose of this pull request?
Implement functionality described in [this issues (202)](https://github.com/palkan/logidze/issues/202)

### What changes did you make? (overview)
I added 2 methods in `Logidze::Meta`:
* `with_responsible!` - for set responsible for the whole lifetime of the connection
* `clear_responsible!` - clear responsible for the whole lifetime of the connection

### Is there anything you'd like reviewers to focus on?
Yes, maybe inheritance from `MetaWithTransaction` class, is wrong?

If there are any comments and suggestions, then I am ready to fix them.

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
