### PR TITLE
fixing issue where destroy fails to delete file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [Fixes [#205](https://github.com/palkan/logidze/issues/205)] Allow `rails destroy logidze:model SomeModel` to delete the migration file.
+
 ## 1.2.0 (2021-06-11)
 
 - Add user-defined exception handling ([@skryukov][])

--- a/README.md
+++ b/README.md
@@ -27,43 +27,29 @@ Other requirements:
 
 ## Table of contents
 
-- [Logidze](#logidze)
-  - [Links](#links)
-  - [Table of contents](#table-of-contents)
-  - [Installation](#installation)
-    - [Using with schema.rb](#using-with-schemarb)
-    - [Configuring models](#configuring-models)
-    - [Backfill data](#backfill-data)
-    - [Log size limits](#log-size-limits)
-    - [Tracking only selected columns](#tracking-only-selected-columns)
-    - [Logs timestamps](#logs-timestamps)
-    - [Undoing a Generate Invocation](#undoing-a-generate-invocation)
-  - [Usage](#usage)
-    - [Basic API](#basic-api)
-    - [Track meta information](#track-meta-information)
-    - [Track responsibility](#track-responsibility)
-    - [Disable logging temporary](#disable-logging-temporary)
-    - [Reset log](#reset-log)
-    - [Full snapshots](#full-snapshots)
-    - [Associations versioning](#associations-versioning)
-  - [Dealing with large logs](#dealing-with-large-logs)
-  - [Handling records deletion](#handling-records-deletion)
-  - [Handling PG exceptions](#handling-pg-exceptions)
-  - [Upgrading](#upgrading)
-    - [Pending upgrade check [Experimental]](#pending-upgrade-check-experimental)
-    - [Upgrading from 0.x to 1.0 (edge)](#upgrading-from-0x-to-10-edge)
-      - [Schema and migrations](#schema-and-migrations)
-      - [API changes](#api-changes)
-  - [Log format](#log-format)
-  - [Troubleshooting](#troubleshooting)
-    - [`log_data` is nil when using Rails fixtures](#log_data-is-nil-when-using-rails-fixtures)
-    - [How to make this work with Apartment 🤔](#how-to-make-this-work-with-apartment-)
-    - [`PG::UntranslatableCharacter: ERROR`](#pguntranslatablecharacter-error)
-    - [`pg_restore` fails to restore a dump](#pg_restore-fails-to-restore-a-dump)
-    - [`PG::NumericValueOutOfRange: ERROR: value overflows numeric format`](#pgnumericvalueoutofrange-error-value-overflows-numeric-format)
-  - [Development](#development)
-  - [Contributing](#contributing)
-  - [License](#license)
+- [Installation & Configuration](#installation)
+  - [Using with schema.rb](#using-with-schemarb)
+  - [Configuring models](#configuring-models)
+  - [Backfill data](#backfill-data)
+  - [Log size limits](#log-size-limits)
+  - [Tracking only selected columns](#tracking-only-selected-columns)
+  - [Logs timestamps](#logs-timestamps)
+  - [Undoing a Generated Invocation](#undoing-a-generated-invocation)
+- [Usage](#usage)
+  - [Basic API](#basic-api)
+  - [Track meta information](#track-meta-information)
+  - [Track responsibility](#track-responsibility)
+  - [Disable logging temporary](#disable-logging-temporary)
+  - [Reset log](#reset-log)
+  - [Creating full snapshot instead of diffs](#full-snapshots)
+  - [Associations versioning](#associations-versioning)
+- [Dealing with large logs](#dealing-with-large-logs)
+- [Handling records deletion](#handling-records-deletion)
+- [Handling PG exceptions](#handling-pg-exceptions)
+- [Upgrading](#upgrading)
+- [Log format](#log-format)
+- [Troubleshooting 🚨](#troubleshooting)
+- [Development](#development)
 
 ## Installation
 
@@ -193,7 +179,7 @@ bundle exec rails generate logidze:model Post --timestamp_column time
 bundle exec rails generate logidze:model Post --timestamp_column nil # "null" and "false" will also work
 ```
 
-### Undoing a Generate Invocation
+### Undoing a Generated Invocation
 
 If you would like to re-do your `rails generate` anew, as with other generators you can use `rails destroy` to revert it, which will delete the migration file and undo the injection of `has_logidze` into the model file:
 

--- a/README.md
+++ b/README.md
@@ -27,28 +27,43 @@ Other requirements:
 
 ## Table of contents
 
-- [Installation & Configuration](#installation)
-  - [Using with schema.rb](#using-with-schemarb)
-  - [Configuring models](#configuring-models)
-  - [Backfill data](#backfill-data)
-  - [Log size limits](#log-size-limits)
-  - [Tracking only selected columns](#tracking-only-selected-columns)
-  - [Logs timestamps](#logs-timestamps)
-- [Usage](#usage)
-  - [Basic API](#basic-api)
-  - [Track meta information](#track-meta-information)
-  - [Track responsibility](#track-responsibility)
-  - [Disable logging temporary](#disable-logging-temporary)
-  - [Reset log](#reset-log)
-  - [Creating full snapshot instead of diffs](#full-snapshots)
-  - [Associations versioning](#associations-versioning)
-- [Dealing with large logs](#dealing-with-large-logs)
-- [Handling records deletion](#handling-records-deletion)
-- [Handling PG exceptions](#handling-pg-exceptions)
-- [Upgrading](#upgrading)
-- [Log format](#log-format)
-- [Troubleshooting 🚨](#troubleshooting)
-- [Development](#development)
+- [Logidze](#logidze)
+  - [Links](#links)
+  - [Table of contents](#table-of-contents)
+  - [Installation](#installation)
+    - [Using with schema.rb](#using-with-schemarb)
+    - [Configuring models](#configuring-models)
+    - [Backfill data](#backfill-data)
+    - [Log size limits](#log-size-limits)
+    - [Tracking only selected columns](#tracking-only-selected-columns)
+    - [Logs timestamps](#logs-timestamps)
+    - [Undoing a Generate Invocation](#undoing-a-generate-invocation)
+  - [Usage](#usage)
+    - [Basic API](#basic-api)
+    - [Track meta information](#track-meta-information)
+    - [Track responsibility](#track-responsibility)
+    - [Disable logging temporary](#disable-logging-temporary)
+    - [Reset log](#reset-log)
+    - [Full snapshots](#full-snapshots)
+    - [Associations versioning](#associations-versioning)
+  - [Dealing with large logs](#dealing-with-large-logs)
+  - [Handling records deletion](#handling-records-deletion)
+  - [Handling PG exceptions](#handling-pg-exceptions)
+  - [Upgrading](#upgrading)
+    - [Pending upgrade check [Experimental]](#pending-upgrade-check-experimental)
+    - [Upgrading from 0.x to 1.0 (edge)](#upgrading-from-0x-to-10-edge)
+      - [Schema and migrations](#schema-and-migrations)
+      - [API changes](#api-changes)
+  - [Log format](#log-format)
+  - [Troubleshooting](#troubleshooting)
+    - [`log_data` is nil when using Rails fixtures](#log_data-is-nil-when-using-rails-fixtures)
+    - [How to make this work with Apartment 🤔](#how-to-make-this-work-with-apartment-)
+    - [`PG::UntranslatableCharacter: ERROR`](#pguntranslatablecharacter-error)
+    - [`pg_restore` fails to restore a dump](#pg_restore-fails-to-restore-a-dump)
+    - [`PG::NumericValueOutOfRange: ERROR: value overflows numeric format`](#pgnumericvalueoutofrange-error-value-overflows-numeric-format)
+  - [Development](#development)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Installation
 
@@ -176,6 +191,14 @@ To change the column name or disable this feature completely, you can use the `t
 bundle exec rails generate logidze:model Post --timestamp_column time
 # will always set version timestamp to `statement_timestamp()`
 bundle exec rails generate logidze:model Post --timestamp_column nil # "null" and "false" will also work
+```
+
+### Undoing a Generate Invocation
+
+If you would like to re-do your `rails generate` anew, as with other generators you can use `rails destroy` to revert it, which will delete the migration file and undo the injection of `has_logidze` into the model file:
+
+```sh
+bundle exec rails destroy logidze:model Post
 ```
 
 **IMPORTANT**: If you use non-UTC time zone for Active Record (`config.active_record.default_timezone`), you MUST always infer log timestamps from a timestamp column (e.g., when back-filling data); otherwise, you may end up with inconsistent logs ([#199](https://github.com/palkan/logidze/issues/199)). In general, we recommend using UTC as the database time unless there is a very strong reason not to.

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -45,7 +45,7 @@ module Logidze
           warn "Use only one: --only or --except"
           exit(1)
         end
-        migration_template "migration.rb.erb", "db/migrate/#{migration_file_name}"
+        migration_template "migration.rb.erb", "db/migrate/#{migration_name}.rb"
       end
 
       def generate_fx_trigger
@@ -71,10 +71,6 @@ module Logidze
           else
             "add_logidze_to_#{plural_table_name}"
           end
-        end
-
-        def migration_file_name
-          "#{migration_name}.rb"
         end
 
         def limit

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -268,5 +268,32 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         expect(file("app/models/custom/data/set.rb")).to contain "has_logidze"
       end
     end
+
+    context "when revoking" do
+      let(:path) { File.join(destination_root, "app", "models", "user.rb") }
+
+      before do
+        File.write(
+          path,
+          <<~RAW
+            class User < ActiveRecord::Base
+            end
+          RAW
+        )
+      end
+
+      let(:path) { File.join(destination_root, "app", "models", "user.rb") }
+      let(:base_args) { ["User"] }
+
+      it "deletes migration file it created" do
+        run_generator(args)
+        migration_file = migration_file("db/migrate/add_logidze_to_users.rb")
+        expect(migration_file).to exist
+
+        Rails::Generators.invoke "logidze:model", args, behavior: :revoke, destination_root: destination_root
+        migration_file = migration_file("db/migrate/add_logidze_to_users.rb")
+        expect(migration_file).not_to exist
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #205

### What is the purpose of this pull request?

As described in #205, currently when someone does `rails generate logidze:model MyModel` and then wants to revoke that generation with `rails destroy logidze:model MyModel`, the injected `has_logidze` is removed from the model file, but the created migration file is not deleted. This PR fixes that.

### What changes did you make? (overview)

Remove the `migration_file_name` method from `ModelGenerator` entirely.

After digging, I discovered that this method was clobbering an `attr_accessor` of the same name in the underlying generator plumbing in `Rails::Generators::Migration` (`lib/rails/generators/migration.rb` in `railties`), which was causing the `migration_exists?` in that same file not to work as expected. This was, in turn, causing code in `Rails::Generators::Actions::CreateMigration` (`lib/rails/generators/actions/create_migration.rb` in `railties`) not to realize that there was already a matching migration file existing with a prior migration number (which we should delete), so it would fall back to using the "current" migration number, for which a file doesn't exist.

### Is there anything you'd like reviewers to focus on?

Are there edge cases or things to consider that I'm not thinking about? I am very new to this codebase and thus fairly unfamiliar, so I have somewhat of "blinders" on and am focused on my specific use case.

### Checklist

- [X] I've added tests for this change
- [X] I've added a Changelog entry
- [X] I've updated a documentation (Readme)
