### PR TITLE
Add support to table_name_prefix and table_name_suffix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -33,6 +33,12 @@ jobs:
           postgres: "13"
           gemfile: "gemfiles/railsmaster.gemfile"
           fx: "false"
+        - ruby: "2.7"
+          postgres: "10"
+          gemfile: "gemfiles/railsmaster.gemfile"
+          fx: "false"
+          table_name_prefix: 'prefix-'
+          table_name_suffix: '-suffix'
         - ruby: "2.6"
           postgres: "9.6"
           gemfile: "gemfiles/rails6.gemfile"
@@ -87,11 +93,15 @@ jobs:
     - name: Run RSpec (unit, integrations)
       env:
         USE_FX: ${{ matrix.fx }}
+        TABLE_NAME_PREFIX: ${{ matrix.table_name_prefix }}
+        TABLE_NAME_SUFFIX: ${{ matrix.table_name_suffix }}
       run: |
         bundle exec rspec --exclude-pattern=spec/acceptance/**/* -f d --force-color
     - name: Run RSpec (acceptance)
       env:
         USE_FX: ${{ matrix.fx }}
+        TABLE_NAME_PREFIX: ${{ matrix.table_name_prefix }}
+        TABLE_NAME_SUFFIX: ${{ matrix.table_name_suffix }}
       run: |
         bundle exec rspec spec/acceptance/ -f d --force-color
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [Fixes [#207](https://github.com/palkan/logidze/issues/207)] Add support for the use of `table_name_prefix` or `table_name_suffix`.
+
 ## 1.2.0 (2021-06-11)
 
 - Add user-defined exception handling ([@skryukov][])

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -77,6 +77,11 @@ module Logidze
           "#{migration_name}.rb"
         end
 
+        def full_table_name
+          config = ActiveRecord::Base
+          "#{config.table_name_prefix}#{table_name}#{config.table_name_suffix}"
+        end
+
         def limit
           options[:limit]
         end

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -77,7 +77,7 @@ module Logidze
           config = ActiveRecord::Base
           "#{config.table_name_prefix}#{table_name}#{config.table_name_suffix}"
         end
-        
+
         def limit
           options[:limit]
         end

--- a/lib/generators/logidze/model/templates/migration.rb.erb
+++ b/lib/generators/logidze/model/templates/migration.rb.erb
@@ -12,14 +12,14 @@ class <%= @migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::M
       dir.up do
     <%- if update? -%>
         # Drop legacy trigger if any (<1.0)
-        execute "DROP TRIGGER IF EXISTS logidze_on_<%= table_name %> on <%= table_name %>;"
+        execute "DROP TRIGGER IF EXISTS \"logidze_on_<%= full_table_name %>\" on \"<%= full_table_name %>\";"
 
     <%- end -%>
         create_trigger :logidze_on_<%= table_name %>, on: :<%= table_name %>
       end
 
       dir.down do
-        execute "DROP TRIGGER IF EXISTS logidze_on_<%= table_name %> on <%= table_name %>;"
+        execute "DROP TRIGGER IF EXISTS \"logidze_on_<%= full_table_name %>\" on \"<%= full_table_name %>\";"
       end
     end
   <%- end -%>
@@ -27,7 +27,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::M
     reversible do |dir|
       dir.up do
   <%- if update? -%>
-        execute "DROP TRIGGER IF EXISTS logidze_on_<%= table_name %> on <%= table_name %>;"
+        execute "DROP TRIGGER IF EXISTS \"logidze_on_<%= full_table_name %>\" on \"<%= full_table_name %>\";"
 
   <%- end -%>
         execute <<~SQL
@@ -44,7 +44,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::M
         # Uncomment this line if you want to raise an error.
         # raise ActiveRecord::IrreversibleMigration
   <%- else -%>
-        execute "DROP TRIGGER IF EXISTS logidze_on_<%= table_name %> on <%= table_name %>;"
+        execute "DROP TRIGGER IF EXISTS \"logidze_on_<%= full_table_name %>\" on \"<%= full_table_name %>\";"
   <%- end -%>
       end
     end
@@ -54,7 +54,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::M
     reversible do |dir|
       dir.up do
         execute <<~SQL
-          UPDATE <%= table_name %> as t
+          UPDATE "<%= full_table_name %>" as t
           SET log_data = logidze_snapshot(<%= logidze_snapshot_parameters %>);
         SQL
       end

--- a/lib/generators/logidze/model/templates/migration.rb.erb
+++ b/lib/generators/logidze/model/templates/migration.rb.erb
@@ -12,14 +12,18 @@ class <%= @migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::M
       dir.up do
     <%- if update? -%>
         # Drop legacy trigger if any (<1.0)
-        execute "DROP TRIGGER IF EXISTS \"logidze_on_<%= full_table_name %>\" on \"<%= full_table_name %>\";"
+        execute <<~SQL
+          DROP TRIGGER IF EXISTS "logidze_on_<%= full_table_name %>" on "<%= full_table_name %>";
+        SQL
 
     <%- end -%>
         create_trigger :logidze_on_<%= table_name %>, on: :<%= table_name %>
       end
 
       dir.down do
-        execute "DROP TRIGGER IF EXISTS \"logidze_on_<%= full_table_name %>\" on \"<%= full_table_name %>\";"
+        execute <<~SQL
+          DROP TRIGGER IF EXISTS "logidze_on_<%= full_table_name %>" on "<%= full_table_name %>";
+        SQL
       end
     end
   <%- end -%>
@@ -27,7 +31,9 @@ class <%= @migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::M
     reversible do |dir|
       dir.up do
   <%- if update? -%>
-        execute "DROP TRIGGER IF EXISTS \"logidze_on_<%= full_table_name %>\" on \"<%= full_table_name %>\";"
+        execute <<~SQL
+          DROP TRIGGER IF EXISTS "logidze_on_<%= full_table_name %>" on "<%= full_table_name %>";
+        SQL
 
   <%- end -%>
         execute <<~SQL
@@ -44,7 +50,9 @@ class <%= @migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::M
         # Uncomment this line if you want to raise an error.
         # raise ActiveRecord::IrreversibleMigration
   <%- else -%>
-        execute "DROP TRIGGER IF EXISTS \"logidze_on_<%= full_table_name %>\" on \"<%= full_table_name %>\";"
+        execute <<~SQL
+          DROP TRIGGER IF EXISTS "logidze_on_<%= full_table_name %>" on "<%= full_table_name %>";
+        SQL
   <%- end -%>
       end
     end

--- a/lib/generators/logidze/model/triggers/logidze.sql
+++ b/lib/generators/logidze/model/triggers/logidze.sql
@@ -1,5 +1,5 @@
-CREATE TRIGGER logidze_on_<%= table_name %>
-BEFORE UPDATE OR INSERT ON <%= table_name %> FOR EACH ROW
+CREATE TRIGGER <%= %Q("logidze_on_#{full_table_name}") %>
+BEFORE UPDATE OR INSERT ON <%= %Q("#{full_table_name}") %> FOR EACH ROW
 WHEN (coalesce(current_setting('logidze.disabled', true), '') <> 'on')
 -- Parameters: history_size_limit (integer), timestamp_column (text), filtered_columns (text[]),
 -- include_columns (boolean), debounce_time_ms (integer)

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -213,7 +213,7 @@ module Logidze
 
     # Loads log_data field from the database, stores to the attributes hash and returns it
     def reload_log_data
-      self.log_data = self.class.where(self.class.primary_key => id).pluck("#{self.class.table_name}.log_data").first
+      self.log_data = self.class.where(self.class.primary_key => id).pluck("#{self.class.table_name}.log_data".to_sym).first
     end
 
     # Nullify log_data column for a single record

--- a/spec/dummy/app/models/not_logged_post.rb
+++ b/spec/dummy/app/models/not_logged_post.rb
@@ -3,7 +3,7 @@
 class NotLoggedPost < ActiveRecord::Base
   has_logidze ignore_log_data: true
 
-  self.table_name = "posts"
+  self.table_name = "#{table_name_prefix}posts#{table_name_suffix}"
 
   belongs_to :user
   has_many :comments, class_name: "NotLoggedPostComment", foreign_key: :post_id

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -11,6 +11,10 @@ Bundler.require(*Rails.groups)
 # Conditionally load fx
 USE_FX = ENV["USE_FX"] == "true"
 
+# Conditionally set table_name_prefix and/or table_name_suffix
+TABLE_NAME_PREFIX = ENV["TABLE_NAME_PREFIX"].presence
+TABLE_NAME_SUFFIX = ENV["TABLE_NAME_SUFFIX"].presence
+
 require "logidze"
 if USE_FX
   require "fx"
@@ -24,5 +28,15 @@ end
 module Dummy
   class Application < Rails::Application
     config.eager_load = false
+
+    if TABLE_NAME_PREFIX
+      $stdout.puts "🔩 Using table_name_prefix = '#{TABLE_NAME_PREFIX}'"
+      config.active_record.table_name_prefix = TABLE_NAME_PREFIX
+    end
+
+    if TABLE_NAME_SUFFIX
+      $stdout.puts "🔩 Using table_name_suffix = '#{TABLE_NAME_SUFFIX}'"
+      config.active_record.table_name_suffix = TABLE_NAME_SUFFIX
+    end
   end
 end

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -12,11 +12,9 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
   let(:table_name_prefix) { TABLE_NAME_PREFIX }
   let(:table_name_suffix) { TABLE_NAME_SUFFIX }
 
-  let(:full_table_name) {
-    ->(table_name) {
-      "#{table_name_prefix}#{table_name}#{table_name_suffix}"
-    }
-  }
+  def full_table_name(table_name)
+    "#{table_name_prefix}#{table_name}#{table_name_suffix}"
+  end
 
   let(:base_args) { [] }
   let(:args) { base_args + fx_args }
@@ -40,7 +38,6 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
       let(:path) { File.join(destination_root, "app", "models", "user.rb") }
       let(:base_args) { ["user"] }
 
-
       before do
         File.write(
           path,
@@ -55,11 +52,11 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         is_expected.to exist
         is_expected.to contain "ActiveRecord::Migration[#{ar_version}]"
         is_expected.to contain "add_column :users, :log_data, :jsonb"
-        is_expected.to contain(/create trigger "logidze_on_#{full_table_name['users']}"/i)
-        is_expected.to contain(/before update or insert on "#{full_table_name['users']}" for each row/i)
+        is_expected.to contain(/create trigger "logidze_on_#{full_table_name('users')}"/i)
+        is_expected.to contain(/before update or insert on "#{full_table_name('users')}" for each row/i)
         is_expected.to contain(/execute procedure logidze_logger\(null, 'updated_at'\);/i)
-        is_expected.to contain(/drop trigger if exists \\\"logidze_on_#{full_table_name['users']}\\\" on \\\"#{full_table_name['users']}\\\"/i)
-        is_expected.not_to contain(/update \\\"#{full_table_name['users']}\\\"/i)
+        is_expected.to contain(/drop trigger if exists "logidze_on_#{full_table_name('users')}" on "#{full_table_name('users')}"/i)
+        is_expected.not_to contain(/update "#{full_table_name('users')}"/i)
 
         expect(file("app/models/user.rb")).to contain "has_logidze"
       end
@@ -123,7 +120,7 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
 
         it "creates backfill query" do
           is_expected.to exist
-          is_expected.to contain(/update \"#{full_table_name['users']}\" as t/i)
+          is_expected.to contain(/update "#{full_table_name('users')}" as t/i)
           is_expected.to contain(/set log_data = logidze_snapshot\(to_jsonb\(t\), 'updated_at'\);/i)
         end
       end
@@ -134,10 +131,10 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         it "creates migration with trigger" do
           is_expected.to exist
           is_expected.not_to contain "add_column :users, :log_data, :jsonb"
-          is_expected.to contain(/create trigger "logidze_on_#{full_table_name['users']}"/i)
-          is_expected.to contain(/before update or insert on "#{full_table_name['users']}" for each row/i)
+          is_expected.to contain(/create trigger "logidze_on_#{full_table_name('users')}"/i)
+          is_expected.to contain(/before update or insert on "#{full_table_name('users')}" for each row/i)
           is_expected.to contain(/execute procedure logidze_logger\(null, 'updated_at'\);/i)
-          is_expected.to contain(/drop trigger if exists \\\"logidze_on_#{full_table_name['users']}\\\" on \\\"#{full_table_name['users']}\\\"/i)
+          is_expected.to contain(/drop trigger if exists "logidze_on_#{full_table_name('users')}" on "#{full_table_name('users')}"/i)
           is_expected.not_to contain "remove_column :users, :log_data"
         end
       end
@@ -153,8 +150,8 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         it "creates migration with drop and create trigger" do
           is_expected.to exist
           is_expected.not_to contain "add_column :users, :log_data, :jsonb"
-          is_expected.to contain(/drop trigger if exists \\\"logidze_on_#{full_table_name['users']}\\\" on \\\"#{full_table_name['users']}\\\"/i)
-          is_expected.to contain(/before update or insert on "#{full_table_name['users']}" for each row/i)
+          is_expected.to contain(/drop trigger if exists "logidze_on_#{full_table_name('users')}" on "#{full_table_name('users')}"/i)
+          is_expected.to contain(/before update or insert on "#{full_table_name('users')}" for each row/i)
           is_expected.to contain "raise ActiveRecord::IrreversibleMigration"
         end
 

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -9,6 +9,15 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
   let(:use_fx_args) { USE_FX ? [] : ["--fx"] }
   let(:fx_args) { USE_FX ? ["--no-fx"] : [] }
 
+  let(:table_name_prefix) { TABLE_NAME_PREFIX }
+  let(:table_name_suffix) { TABLE_NAME_SUFFIX }
+
+  let(:full_table_name) {
+    ->(table_name) {
+      "#{table_name_prefix}#{table_name}#{table_name_suffix}"
+    }
+  }
+
   let(:base_args) { [] }
   let(:args) { base_args + fx_args }
   let(:ar_version) { "6.0" }
@@ -31,6 +40,7 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
       let(:path) { File.join(destination_root, "app", "models", "user.rb") }
       let(:base_args) { ["user"] }
 
+
       before do
         File.write(
           path,
@@ -45,11 +55,11 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         is_expected.to exist
         is_expected.to contain "ActiveRecord::Migration[#{ar_version}]"
         is_expected.to contain "add_column :users, :log_data, :jsonb"
-        is_expected.to contain(/create trigger logidze_on_users/i)
-        is_expected.to contain(/before update or insert on users for each row/i)
+        is_expected.to contain(/create trigger "logidze_on_#{full_table_name['users']}"/i)
+        is_expected.to contain(/before update or insert on "#{full_table_name['users']}" for each row/i)
         is_expected.to contain(/execute procedure logidze_logger\(null, 'updated_at'\);/i)
-        is_expected.to contain(/drop trigger if exists logidze_on_users on users/i)
-        is_expected.not_to contain(/update users/i)
+        is_expected.to contain(/drop trigger if exists \\\"logidze_on_#{full_table_name['users']}\\\" on \\\"#{full_table_name['users']}\\\"/i)
+        is_expected.not_to contain(/update \\\"#{full_table_name['users']}\\\"/i)
 
         expect(file("app/models/user.rb")).to contain "has_logidze"
       end
@@ -113,7 +123,7 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
 
         it "creates backfill query" do
           is_expected.to exist
-          is_expected.to contain(/update users as t/i)
+          is_expected.to contain(/update \"#{full_table_name['users']}\" as t/i)
           is_expected.to contain(/set log_data = logidze_snapshot\(to_jsonb\(t\), 'updated_at'\);/i)
         end
       end
@@ -124,10 +134,10 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         it "creates migration with trigger" do
           is_expected.to exist
           is_expected.not_to contain "add_column :users, :log_data, :jsonb"
-          is_expected.to contain(/create trigger logidze_on_users/i)
-          is_expected.to contain(/before update or insert on users for each row/i)
+          is_expected.to contain(/create trigger "logidze_on_#{full_table_name['users']}"/i)
+          is_expected.to contain(/before update or insert on "#{full_table_name['users']}" for each row/i)
           is_expected.to contain(/execute procedure logidze_logger\(null, 'updated_at'\);/i)
-          is_expected.to contain(/drop trigger if exists logidze_on_users on users/i)
+          is_expected.to contain(/drop trigger if exists \\\"logidze_on_#{full_table_name['users']}\\\" on \\\"#{full_table_name['users']}\\\"/i)
           is_expected.not_to contain "remove_column :users, :log_data"
         end
       end
@@ -143,8 +153,8 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         it "creates migration with drop and create trigger" do
           is_expected.to exist
           is_expected.not_to contain "add_column :users, :log_data, :jsonb"
-          is_expected.to contain(/drop trigger if exists logidze_on_users/i)
-          is_expected.to contain(/before update or insert on users for each row/i)
+          is_expected.to contain(/drop trigger if exists \\\"logidze_on_#{full_table_name['users']}\\\" on \\\"#{full_table_name['users']}\\\"/i)
+          is_expected.to contain(/before update or insert on "#{full_table_name['users']}" for each row/i)
           is_expected.to contain "raise ActiveRecord::IrreversibleMigration"
         end
 


### PR DESCRIPTION
Address the issue #207 

### What is the purpose of this pull request?
As described in #207, there is no support for when the `config.active_record.table_name_prefix` or `config.active_record.table_name_suffix` are defined. This PR fixes what's relevant to `logidze`.

### What changes did you make? (overview)
 - I add the method `full_table_name` as suggested by @palkan in the issue #207. 
 - Quoted all the references to table or triggers names, in order to safely handle prefixes or suffixes that include for instance a `-` (hyphen). I explore the idea of using the `quote_table_name()` method on the connection for it but was not sure what approach do you prefer? what I thought that maybe we can have something like:

 ```ruby
def quote_db_object_name(object_name)
  ActiveRecord::Base.connection.quote_table_name(object_name)
end
```
The idea of having a method like this, is so that we can pass for instance `logidze_on_#{full_table_name}` and not only table names. And also because this gem supports only PG not sure if make sense to have this in there. 

 - On the `Logidze::Model` I tweak the method `reload_log_data` in order to prevent the raise of the `ActiveRecord::Sanitization::ClassMethods#disallow_raw_sql!`
 - Changes on the specs to properly match the `"` (quotes) on the object names

### Is there anything you'd like reviewers to focus on?

- It's important to have in mind that this changes did not addresses the issue with the naming of the `fx` functions or triggers. I open [an issue](https://github.com/teoljungberg/fx/issues/81) over there in order to know if it's something that's in the scope of the gem 
- Also because there are multiline and onliners SQL sometimes we need a escaped quote and sometimes we don't not sure if you want to move everything to use the `<<~SQL` and in such the quotation can be more consistent.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] ~I've updated a documentation (Readme)~
