### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,6 +25,14 @@ jobs:
         ]
         fx: ["false"]
         include:
+        - ruby: "3.1"
+          postgres: "14"
+          gemfile: "gemfiles/railsmaster.gemfile"
+          fx: "false"
+        - ruby: "3.1"
+          postgres: "14"
+          gemfile: "gemfiles/rails7.gemfile"
+          fx: "false"
         - ruby: "3.0"
           postgres: "14"
           gemfile: "gemfiles/rails7.gemfile"

--- a/gemfiles/rails7.gemfile
+++ b/gemfiles/rails7.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-rails_version = '7.0.0.rc1'
+rails_version = '~> 7.0.0'
 gem 'railties', rails_version
 gem 'activerecord', rails_version
 gem 'rspec-rails', '>= 4.0'

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org" do
-  gem "rubocop-md", "~> 1.0"
-  gem "standard", "~> 0.10"
-end
+source 'https://rubygems.org'
+
+gem "rubocop-md", "~> 1.0"
+gem "standard", "~> 0.10"


### PR DESCRIPTION
### What is the purpose of this pull request?

To add Ruby 3.1 to the CI matrix, so consumers of the gem can have confidence it works with Ruby 3.1

### What changes did you make? (overview)

1. Updated the CI configuration
2. Changed the version in the Rails 7 gemfile from `7.0.0.rc1` to `~> 7.0.0`
3. Fixed a warning being generated by the `rubocop.gemfile`

### Is there anything you'd like reviewers to focus on?

Nope

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
