### PR TITLE
Switch to fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [Fixes [#217](https://github.com/palkan/logidze/issues/217)] Fix switch_to with `append: true` when there are changes on JSONB columns. ([@miharekar][])
+
 ## 1.2.2 (2022-07-13)
 
 - [Fixes [#209](https://github.com/palkan/logidze/issues/209)] Fix tracking JSONB column changes. ([@baygeldin][])
@@ -66,7 +68,7 @@ now we filter the columns within the trigger function (thus, schema changes do n
 
 - PR [#143](https://github.com/palkan/logidze/pull/143) Add `:transactional` option to `#with_meta` and `#with_responsible` ([@oleg-kiviljov][])
 
-Now it's possible to set meta and responsible without wrapping the block into a DB transaction. For backward compatibility  `:transactional` option by default is set to `true`.
+Now it's possible to set meta and responsible without wrapping the block into a DB transaction. For backward compatibility `:transactional` option by default is set to `true`.
 
 Usage:
 

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -172,6 +172,8 @@ module Logidze
     # Restore record to the specified version.
     # Return false if version is unknown.
     def switch_to!(version, append: Logidze.append_on_undo)
+      raise ArgumentError, "#log_data is empty" unless log_data
+
       return false unless at_version(version)
 
       if append && version < log_version

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -177,8 +177,9 @@ module Logidze
       return false unless at_version(version)
 
       if append && version < log_version
-        deserialized_changes = log_data.changes_to(version: version).to_h { |c, v| [c, deserialize_value(c, v)] }
-        update!(deserialized_changes)
+        changes = log_data.changes_to(version: version)
+        changes.each { |c, v| changes[c] = deserialize_value(c, v) }
+        update!(changes)
       else
         at_version!(version)
         self.class.without_logging { save! }

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -177,7 +177,8 @@ module Logidze
       return false unless at_version(version)
 
       if append && version < log_version
-        update!(log_data.changes_to(version: version))
+        deserialized_changes = log_data.changes_to(version: version).to_h { |c, v| [c, deserialize_value(c, v)] }
+        update!(deserialized_changes)
       else
         at_version!(version)
         self.class.without_logging { save! }

--- a/spec/integration/triggers_spec.rb
+++ b/spec/integration/triggers_spec.rb
@@ -286,7 +286,7 @@ describe "triggers", :db do
   end
 
   describe "switch_to!" do
-    before(:all) { @post = Post.create!(title: "Triggers", rating: 10) }
+    before(:all) { @post = Post.create!(title: "Triggers", rating: 10, data: {some: "json"}) }
     after(:all) { @post.destroy! }
 
     let(:post) { @post.reload }
@@ -308,6 +308,17 @@ describe "triggers", :db do
       expect(post.log_version).to eq 3
       expect(post.log_size).to eq 3
       expect(post.rating).to eq 10
+    end
+
+    it "handles JSONB correctly when append: true", :aggregate_failures do
+      post.update!(rating: 5, meta: {tags: %w[jsonb json]}, data: {json: "here"})
+      post.reload.switch_to!(1, append: true)
+      post.reload
+
+      expect(post.log_version).to eq 3
+      expect(post.log_size).to eq 3
+      expect(post.rating).to eq 10
+      expect(post.data).to eq({"some" => "json"})
     end
 
     it "reverts to specified version if it's newer than current version", :aggregate_failures do

--- a/spec/logidze/model_spec.rb
+++ b/spec/logidze/model_spec.rb
@@ -235,6 +235,11 @@ describe Logidze::Model, :db do
     it "return false if version is unknown" do
       expect(user.switch_to!(10)).to eq false
     end
+
+    it "raises ArgumentError if log_data is nil" do
+      user.log_data = nil
+      expect { user.switch_to!(3) }.to raise_error(ArgumentError)
+    end
   end
 
   describe ".at" do


### PR DESCRIPTION
Fixes #217

Additionally, I've added a log_data check in `switch_to!`. When `append` is false the check would happen in `at_version!`, but when it's true the method would fail.

Now we always check and raise on nil.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
