### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -20,7 +20,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
@@ -31,7 +31,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
@@ -43,7 +43,7 @@ jobs:
   forspell:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Hunspell
       run: |
         sudo apt-get install hunspell
@@ -51,7 +51,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: Cache installed gems
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: /home/runner/.rubies/ruby-2.7.0/lib/ruby/gems/2.7.0
         key: gems-cache-${{ runner.os }}
@@ -64,7 +64,7 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Go
       uses: actions/setup-go@v1
       with:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,6 +25,14 @@ jobs:
         ]
         fx: ["false"]
         include:
+        - ruby: "3.2"
+          postgres: "14"
+          gemfile: "gemfiles/railsmaster.gemfile"
+          fx: "false"
+        - ruby: "3.2"
+          postgres: "14"
+          gemfile: "gemfiles/rails7.gemfile"
+          fx: "false"
         - ruby: "3.1"
           postgres: "14"
           gemfile: "gemfiles/railsmaster.gemfile"
@@ -75,8 +83,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
       with:
         path: /home/runner/bundle
         key: bundle-${{ matrix.ruby }}-${{ matrix.gemfile }}-${{ hashFiles(matrix.gemfile) }}-${{ hashFiles('**/*.gemspec') }}


### PR DESCRIPTION
Adds Ruby 3.2 to the CI matrix.
Also updates the checkout and cache action versions.

### What is the purpose of this pull request?

To ensure the gem is tested against Ruby 3.2

### What changes did you make? (overview)

Updated CI

### Is there anything you'd like reviewers to focus on?

Nope

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
