### PR TITLE
Add --after_trigger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Other requirements:
   - [Tracking only selected columns](#tracking-only-selected-columns)
   - [Logs timestamps](#logs-timestamps)
   - [Undoing a Generated Invocation](#undoing-a-generated-invocation)
+  - [After trigger](#after-trigger)
 - [Usage](#usage)
   - [Basic API](#basic-api)
   - [Track meta information](#track-meta-information)
@@ -188,6 +189,17 @@ bundle exec rails destroy logidze:model Post
 ```
 
 **IMPORTANT**: If you use non-UTC time zone for Active Record (`config.active_record.default_timezone`), you MUST always infer log timestamps from a timestamp column (e.g., when back-filling data); otherwise, you may end up with inconsistent logs ([#199](https://github.com/palkan/logidze/issues/199)). In general, we recommend using UTC as the database time unless there is a very strong reason not to.
+
+### After trigger
+
+To generate an after trigger, you can provide the `after_trigger` option.
+
+```sh
+bundle exec rails generate logidze:model Post --after_trigger
+```
+
+It only makes sense if you are using partition tables that do not support before trigger. 
+This way has a limitation. Record changes are written as a full snapshot if the partition has changed.
 
 ## Usage
 

--- a/lib/generators/logidze/install/functions/logidze_logger_after.sql
+++ b/lib/generators/logidze/install/functions/logidze_logger_after.sql
@@ -1,0 +1,196 @@
+CREATE OR REPLACE FUNCTION logidze_logger_after() RETURNS TRIGGER AS $body$
+-- version: 3
+DECLARE
+  changes         jsonb;
+  version         jsonb;
+  snapshot        jsonb;
+  new_v           integer;
+  size            integer;
+  history_limit   integer;
+  debounce_time   integer;
+  current_version integer;
+  k               text;
+  iterator        integer;
+  item            record;
+  columns         text[];
+  include_columns boolean;
+  ts              timestamp with time zone;
+  ts_column       text;
+  err_sqlstate    text;
+  err_message     text;
+  err_detail      text;
+  err_hint        text;
+  err_context     text;
+  err_table_name  text;
+  err_schema_name text;
+  err_jsonb       jsonb;
+  err_captured    boolean;
+BEGIN
+  ts_column := NULLIF(TG_ARGV[1], 'null');
+  columns := NULLIF(TG_ARGV[2], 'null');
+  include_columns := NULLIF(TG_ARGV[3], 'null');
+
+  IF (NEW.log_data IS NULL OR NEW.log_data = '{}'::jsonb) THEN
+    IF columns IS NOT NULL THEN
+      snapshot = logidze_snapshot(to_jsonb(NEW.*), ts_column, columns, include_columns);
+    ELSE
+      snapshot = logidze_snapshot(to_jsonb(NEW.*), ts_column);
+    END IF;
+
+    IF snapshot #>> '{h, -1, c}' != '{}' THEN
+      EXECUTE format('UPDATE %I.%I SET log_data = %L WHERE ctid = %L', TG_TABLE_SCHEMA, TG_TABLE_NAME, snapshot, NEW.CTID);
+    END IF;
+
+  ELSE
+
+    IF TG_OP = 'UPDATE' AND (OLD.log_data != NEW.log_data OR to_jsonb(NEW.*) = to_jsonb(OLD.*)) THEN
+      RETURN NULL;
+    END IF;
+
+    history_limit := NULLIF(TG_ARGV[0], 'null');
+    debounce_time := NULLIF(TG_ARGV[4], 'null');
+
+    current_version := (NEW.log_data ->> 'v')::int;
+
+    IF ts_column IS NULL THEN
+      ts := statement_timestamp();
+    ELSEIF TG_OP = 'UPDATE' THEN
+      ts := (to_jsonb(NEW.*) ->> ts_column)::timestamp with time zone;
+      IF ts IS NULL OR ts = (to_jsonb(OLD.*) ->> ts_column)::timestamp with time zone THEN
+        ts := statement_timestamp();
+      END IF;
+    ELSEIF TG_OP = 'INSERT' THEN
+      ts := (to_jsonb(NEW.*) ->> ts_column)::timestamp with time zone;
+      IF ts IS NULL OR (extract(epoch from ts) * 1000)::bigint = (NEW.log_data #>> '{h,-1,ts}')::bigint THEN
+        ts := statement_timestamp();
+      END IF;
+    END IF;
+
+    IF current_version < (NEW.log_data #>> '{h,-1,v}')::int THEN
+      iterator := 0;
+      FOR item in SELECT * FROM jsonb_array_elements(NEW.log_data -> 'h')
+        LOOP
+          IF (item.value ->> 'v')::int > current_version THEN
+            NEW.log_data := jsonb_set(
+                NEW.log_data,
+                '{h}',
+                (NEW.log_data -> 'h') - iterator
+              );
+          END IF;
+          iterator := iterator + 1;
+        END LOOP;
+    END IF;
+
+    changes := '{}';
+
+    IF TG_OP = 'INSERT' OR (coalesce(current_setting('logidze.full_snapshot', true), '') = 'on') THEN
+      BEGIN
+        changes = hstore_to_jsonb_loose(hstore(NEW.*));
+      EXCEPTION
+        WHEN NUMERIC_VALUE_OUT_OF_RANGE THEN
+          changes = row_to_json(NEW.*)::jsonb;
+          FOR k IN (SELECT key FROM jsonb_each(changes))
+            LOOP
+              IF jsonb_typeof(changes -> k) = 'object' THEN
+                changes = jsonb_set(changes, ARRAY [k], to_jsonb(changes ->> k));
+              END IF;
+            END LOOP;
+      END;
+    ELSE
+      BEGIN
+        changes = hstore_to_jsonb_loose(
+            hstore(NEW.*) - hstore(OLD.*)
+          );
+      EXCEPTION
+        WHEN NUMERIC_VALUE_OUT_OF_RANGE THEN
+          changes = (SELECT COALESCE(json_object_agg(key, value), '{}')::jsonb
+                     FROM
+                       jsonb_each(row_to_json(NEW.*)::jsonb)
+                     WHERE NOT jsonb_build_object(key, value) <@ row_to_json(OLD.*)::jsonb);
+          FOR k IN (SELECT key FROM jsonb_each(changes))
+            LOOP
+              IF jsonb_typeof(changes -> k) = 'object' THEN
+                changes = jsonb_set(changes, ARRAY [k], to_jsonb(changes ->> k));
+              END IF;
+            END LOOP;
+      END;
+    END IF;
+
+    changes = changes - 'log_data';
+
+    IF columns IS NOT NULL THEN
+      changes = logidze_filter_keys(changes, columns, include_columns);
+    END IF;
+
+    IF changes = '{}' THEN
+      RETURN NULL;
+    END IF;
+
+    new_v := (NEW.log_data #>> '{h,-1,v}')::int + 1;
+
+    size := jsonb_array_length(NEW.log_data -> 'h');
+    version := logidze_version(new_v, changes, ts);
+
+    IF (
+        debounce_time IS NOT NULL AND
+        (version ->> 'ts')::bigint - (NEW.log_data #> '{h,-1,ts}')::text::bigint <= debounce_time
+      ) THEN
+      -- merge new version with the previous one
+      new_v := (NEW.log_data #>> '{h,-1,v}')::int;
+      version := logidze_version(new_v, (NEW.log_data #> '{h,-1,c}')::jsonb || changes, ts);
+      -- remove the previous version from log
+      NEW.log_data := jsonb_set(
+          NEW.log_data,
+          '{h}',
+          (NEW.log_data -> 'h') - (size - 1)
+        );
+    END IF;
+
+    NEW.log_data := jsonb_set(
+        NEW.log_data,
+        ARRAY ['h', size::text],
+        version,
+        true
+      );
+
+    NEW.log_data := jsonb_set(
+        NEW.log_data,
+        '{v}',
+        to_jsonb(new_v)
+      );
+
+    IF history_limit IS NOT NULL AND history_limit <= size THEN
+      NEW.log_data := logidze_compact_history(NEW.log_data, size - history_limit + 1);
+    END IF;
+
+    EXECUTE format('UPDATE %I.%I SET log_data = %L WHERE ctid = %L', TG_TABLE_SCHEMA, TG_TABLE_NAME, NEW.log_data, NEW.CTID);
+  END IF;
+
+  RETURN NULL;
+EXCEPTION
+  WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS err_sqlstate = RETURNED_SQLSTATE,
+      err_message = MESSAGE_TEXT,
+      err_detail = PG_EXCEPTION_DETAIL,
+      err_hint = PG_EXCEPTION_HINT,
+      err_context = PG_EXCEPTION_CONTEXT,
+      err_schema_name = SCHEMA_NAME,
+      err_table_name = TABLE_NAME;
+    err_jsonb := jsonb_build_object(
+        'returned_sqlstate', err_sqlstate,
+        'message_text', err_message,
+        'pg_exception_detail', err_detail,
+        'pg_exception_hint', err_hint,
+        'pg_exception_context', err_context,
+        'schema_name', err_schema_name,
+        'table_name', err_table_name
+      );
+    err_captured = logidze_capture_exception(err_jsonb);
+    IF err_captured THEN
+      return NEW;
+    ELSE
+      RAISE;
+    END IF;
+END;
+$body$
+LANGUAGE plpgsql;

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -40,6 +40,8 @@ module Logidze
       class_option :update, type: :boolean, optional: true,
                             desc: "Define whether this is an update migration"
 
+      class_option :after_trigger, type: :boolean, optional: true, desc: "Use after trigger"
+
       def generate_migration
         if options[:except] && options[:only]
           warn "Use only one: --only or --except"
@@ -92,6 +94,10 @@ module Logidze
 
         def update?
           options[:update]
+        end
+
+        def after_trigger?
+          options[:after_trigger]
         end
 
         def filtered_columns

--- a/lib/generators/logidze/model/templates/migration.rb.erb
+++ b/lib/generators/logidze/model/templates/migration.rb.erb
@@ -37,7 +37,7 @@ class <%= @migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::M
 
   <%- end -%>
         execute <<~SQL
-<%= inject_sql("logidze.sql", indent: 10) %>
+<%= inject_sql(after_trigger? ? "logidze_after.sql" : "logidze.sql", indent: 10) %>
         SQL
       end
 

--- a/lib/generators/logidze/model/triggers/logidze_after.sql
+++ b/lib/generators/logidze/model/triggers/logidze_after.sql
@@ -1,0 +1,6 @@
+CREATE TRIGGER <%= %Q("logidze_on_#{full_table_name}") %>
+AFTER UPDATE OR INSERT ON <%= %Q("#{full_table_name}") %> FOR EACH ROW
+WHEN (coalesce(current_setting('logidze.disabled', true), '') <> 'on')
+-- Parameters: history_size_limit (integer), timestamp_column (text), filtered_columns (text[]),
+-- include_columns (boolean), debounce_time_ms (integer)
+EXECUTE PROCEDURE logidze_logger_after(<%= logidze_logger_parameters %>);

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -53,6 +53,7 @@ end
 
 RSpec.configure do |config|
   config.include Logidze::AcceptanceHelpers
+  config.include Logidze::PostgresHelpers
 
   config.around(:each) do |example|
     Dir.chdir("#{File.dirname(__FILE__)}/dummy") do

--- a/spec/dummy/app/models/partitioned_user.rb
+++ b/spec/dummy/app/models/partitioned_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PartitionedUser < ActiveRecord::Base
+  self.primary_key = "id"
+
+  has_logidze
+end

--- a/spec/dummy/db/migrate/20230202071021_create_partitioned_users.rb
+++ b/spec/dummy/db/migrate/20230202071021_create_partitioned_users.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreatePartitionedUsers < ActiveRecord::Migration[5.0]
+  def up
+    pg_version = select_value("SELECT current_setting('server_version_num')::int;")
+    return if pg_version < 12_00_00
+
+    execute <<~SQL
+      CREATE TABLE partitioned_users (
+        id         serial,
+        name       varchar,
+        age        integer,
+        active     boolean,
+        extra      jsonb,
+        settings   character varying[],
+        created_at timestamp not null,
+        updated_at timestamp not null
+      ) PARTITION BY RANGE (age);
+        
+      CREATE TABLE partitioned_users_minor   PARTITION OF partitioned_users FOR VALUES FROM (0) TO (18);
+      CREATE TABLE partitioned_users_default PARTITION OF partitioned_users DEFAULT;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP TABLE IF EXISTS partitioned_users CASCADE;
+    SQL
+  end
+end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -27,6 +27,7 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
       is_expected.to exist
       is_expected.to contain "ActiveRecord::Migration[#{ar_version}]"
       is_expected.to contain(/create or replace function logidze_logger()/i)
+      is_expected.to contain(/create or replace function logidze_logger_after()/i)
       is_expected.to contain(/create or replace function logidze_snapshot/i)
       is_expected.to contain(/create or replace function logidze_filter_keys/i)
       is_expected.to contain(/create or replace function logidze_compact_history/i)
@@ -42,6 +43,7 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
         is_expected.to exist
         is_expected.to contain "ActiveRecord::Migration[#{ar_version}]"
         is_expected.to contain("create_function :logidze_logger, version: 3")
+        is_expected.to contain("create_function :logidze_logger_after, version: 3")
         is_expected.to contain("create_function :logidze_snapshot, version: 3")
         is_expected.to contain("create_function :logidze_version, version: 2")
         is_expected.to contain("create_function :logidze_filter_keys, version: 1")
@@ -49,6 +51,7 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
         is_expected.to contain("create_function :logidze_capture_exception, version: 1")
 
         is_expected.to contain("DROP FUNCTION IF EXISTS logidze_logger")
+        is_expected.to contain("DROP FUNCTION IF EXISTS logidze_logger_after")
         is_expected.to contain("DROP FUNCTION IF EXISTS logidze_snapshot")
         is_expected.to contain("DROP FUNCTION IF EXISTS logidze_version")
         is_expected.to contain("DROP FUNCTION IF EXISTS logidze_filter_keys")
@@ -62,6 +65,7 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
         is_expected.to exist
         %w[
           logidze_logger_v03.sql
+          logidze_logger_after_v03.sql
           logidze_version_v02.sql
           logidze_filter_keys_v01.sql
           logidze_snapshot_v03.sql
@@ -100,6 +104,7 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
 
       is_expected.to exist
       is_expected.to contain(/create or replace function logidze_logger()/i)
+      is_expected.to contain(/create or replace function logidze_logger_after()/i)
       is_expected.to contain(/create or replace function logidze_snapshot/i)
       is_expected.to contain(/create or replace function logidze_version/i)
       is_expected.to contain(/create or replace function logidze_filter_keys/i)
@@ -117,6 +122,7 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
           logidze_filter_keys_v01.sql
           logidze_compact_history_v05.sql
           logidze_logger_v7.sql
+          logidze_logger_after_v7.sql
         ]
       end
 
@@ -144,6 +150,7 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
         is_expected.not_to contain("update_function :logidze_filter_keys")
         is_expected.to contain("update_function :logidze_compact_history, version: 1, revert_to_version: 5")
         is_expected.to contain("update_function :logidze_logger, version: 3, revert_to_version: 7")
+        is_expected.to contain("update_function :logidze_logger_after, version: 3, revert_to_version: 7")
         is_expected.to contain("create_function :logidze_capture_exception")
       end
 
@@ -153,6 +160,7 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
         is_expected.to exist
         %w[
           logidze_logger_v03.sql
+          logidze_logger_after_v03.sql
           logidze_version_v02.sql
           logidze_snapshot_v03.sql
           logidze_compact_history_v01.sql

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -218,6 +218,16 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
           end
         end
       end
+
+      context "with trigger type" do
+        let(:base_args) { ["user", "--after_trigger"] }
+
+        it "use after trigger" do
+          is_expected.to exist
+          is_expected.to contain(/after update or insert on "#{full_table_name('users')}" for each row/i)
+          is_expected.to contain(/execute procedure logidze_logger_after\(null, 'updated_at'\);/i)
+        end
+      end
     end
 
     context "with namespace" do

--- a/spec/integration/debounce_time_spec.rb
+++ b/spec/integration/debounce_time_spec.rb
@@ -2,12 +2,12 @@
 
 require "acceptance_helper"
 
-describe "trigger debounce", :db do
+shared_context "trigger_debounce_context" do |generator_arg|
   include_context "cleanup migrations"
 
   before(:all) do
     Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-      successfully "rails generate logidze:model post --debounce_time=5000"
+      successfully "rails generate logidze:model post #{generator_arg} --debounce_time=5000"
       successfully "rake db:migrate"
 
       # Close active connections to handle db variables
@@ -69,5 +69,15 @@ describe "trigger debounce", :db do
 
     expect(post.reload.log_version).to eq 3
     expect(post.log_size).to eq 3
+  end
+end
+
+describe "trigger debounce", :db do
+  describe "before update or insert" do
+    include_context "trigger_debounce_context"
+  end
+
+  describe "after update or insert" do
+    include_context "trigger_debounce_context", "--after_trigger"
   end
 end

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -2,7 +2,7 @@
 
 require "acceptance_helper"
 
-describe "columns filtering", :db do
+shared_context "columns_filtering_context" do |generator_arg|
   it "cannot be used with both only and except options" do
     Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
       unsuccessfully "rails generate logidze:model post "\
@@ -17,7 +17,7 @@ describe "columns filtering", :db do
       @except = %w[updated_at created_at active]
 
       Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-        successfully "rails generate logidze:model post "\
+        successfully "rails generate logidze:model post #{generator_arg} "\
                      "--except=#{@except.join(" ")}"
         successfully "rake db:migrate"
 
@@ -73,7 +73,7 @@ describe "columns filtering", :db do
       @only = %w[title meta]
 
       Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-        successfully "rails generate logidze:model post "\
+        successfully "rails generate logidze:model post #{generator_arg} "\
                      "--only=#{@only.join(" ")}"
         successfully "rake db:migrate"
 
@@ -128,7 +128,7 @@ describe "columns filtering", :db do
       @only = %w[title rating]
 
       Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-        successfully "rails generate logidze:model post "\
+        successfully "rails generate logidze:model post #{generator_arg} "\
                      "--only=#{@only.join(" ")}"
         successfully "rake db:migrate"
 
@@ -150,7 +150,7 @@ describe "columns filtering", :db do
       ActiveRecord::Base.connection_pool.disconnect!
 
       Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-        successfully "rails generate logidze:model post --except=updated_at --update"
+        successfully "rails generate logidze:model post #{generator_arg} --except=updated_at --update"
         successfully "rake db:migrate"
 
         ActiveRecord::Base.connection_pool.disconnect!
@@ -163,5 +163,15 @@ describe "columns filtering", :db do
       changes2 = post2.log_data.current_version.changes
       expect(changes2.keys).to match_array Post.column_names - %w[updated_at log_data]
     end
+  end
+end
+
+describe "сolumns filtering", :db do
+  describe "before update or insert" do
+    include_context "columns_filtering_context"
+  end
+
+  describe "after update or insert" do
+    include_context "columns_filtering_context", "--after_trigger"
   end
 end

--- a/spec/integration/ignore_log_data_spec.rb
+++ b/spec/integration/ignore_log_data_spec.rb
@@ -3,13 +3,13 @@
 require "spec_helper"
 require "acceptance_helper"
 
-describe "ignore log columns", :db do
+shared_context "ignore_log_columns_context" do |generator_arg|
   include_context "cleanup migrations"
 
   before(:all) do
     Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-      successfully "rails generate logidze:model post"
-      successfully "rails generate logidze:model post_comment"
+      successfully "rails generate logidze:model post #{generator_arg}"
+      successfully "rails generate logidze:model post_comment #{generator_arg}"
       successfully "rake db:migrate"
 
       # Close active connections to handle db variables
@@ -67,5 +67,15 @@ describe "ignore log columns", :db do
         end
       end
     end
+  end
+end
+
+describe "ignore log columns", :db do
+  describe "before update or insert" do
+    include_context "ignore_log_columns_context"
+  end
+
+  describe "after update or insert" do
+    include_context "ignore_log_columns_context", "--after_trigger"
   end
 end

--- a/spec/integration/meta_spec.rb
+++ b/spec/integration/meta_spec.rb
@@ -2,12 +2,12 @@
 
 require "acceptance_helper"
 
-describe "logs metadata", :db do
+shared_context "logs_metadata_context" do |generator_arg|
   include_context "cleanup migrations"
 
   before(:all) do
     Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-      successfully "rails generate logidze:model user --only-trigger --limit=5"
+      successfully "rails generate logidze:model user #{generator_arg} --only-trigger --limit=5"
       successfully "rake db:migrate"
 
       # Close active connections to handle db variables
@@ -362,5 +362,15 @@ describe "logs metadata", :db do
         expect(subject.at_version(3).whodunnit).to eq responsible2
       end
     end
+  end
+end
+
+describe "logs metadata", :db do
+  describe "before update or insert" do
+    include_examples "logs_metadata_context"
+  end
+
+  describe "after update or insert" do
+    include_examples "logs_metadata_context", "--after_trigger"
   end
 end

--- a/spec/integration/partition_spec.rb
+++ b/spec/integration/partition_spec.rb
@@ -2,62 +2,64 @@
 
 require "acceptance_helper"
 
-describe "partition change imitation", :db do
-  include_context "cleanup migrations"
+describe "partition change", :db do
+  context "partitioned by age" do
+    include_context "cleanup migrations"
 
-  before(:all) do
-    Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-      successfully "rails generate logidze:model post --after_trigger"
-      successfully "rake db:migrate"
+    before(:all) do
+      skip_database_versions(0...12_00_00)
 
-      # Close active connections to handle db variables
-      ActiveRecord::Base.connection_pool.disconnect!
-    end
+      Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
+        successfully "rails generate logidze:model partitioned_user --after_trigger"
+        successfully "rake db:migrate"
 
-    Post.reset_column_information
-  end
-
-  describe "update" do
-    let(:initial_log_data) { Post.create!(title: "Partition Post", rating: 5, active: true).reload.log_data }
-
-    it "creates a new version like a full snapshot", :aggregate_failures do
-      post = Post.create!(title: "Partition Post", active: true, rating: 25, log_data: initial_log_data)
-
-      expect(post.reload.log_version).to eq 2
-      expect(post.log_data.versions.last.changes)
-        .to include("title" => "Partition Post", "rating" => 25, "active" => true)
-
-      post.update!(rating: 30)
-
-      expect(post.reload.log_version).to eq 3
-      expect(post.log_data.versions.last.changes)
-        .to include("rating" => 30)
-      expect(post.log_data.versions.last.changes.keys)
-        .not_to include("title", "active")
-    end
-  end
-
-  describe "timestamp_column is not set" do
-    let(:initial_log_data) { Post.create!(rating: 10, updated_at: Time.at(0)).reload.log_data }
-
-    it "uses 'updated_at' column if it exists", :aggregate_failures do
-      post = nil
-      Timecop.freeze(Time.at(1_000_000)) do
-        post = Post.create!(rating: 20, log_data: initial_log_data)
+        # Close active connections to handle db variables
+        ActiveRecord::Base.connection_pool.disconnect!
       end
 
-      expect(post.reload.log_version).to eq 2
-      expect(post).to use_timestamp(:updated_at)
+      PartitionedUser.reset_column_information
     end
 
-    it "sets version timestamp to statement_timestamp() if 'updated_at' did not change", :aggregate_failures do
-      post = nil
-      Timecop.freeze(Time.at(0)) do
-        post = Post.create!(rating: 20, log_data: initial_log_data)
+    describe "update" do
+      let(:partitioned_user) { PartitionedUser.create!(name: "Partition User", age: 5, active: true).reload }
+
+      it "creates a new version like a full snapshot", :aggregate_failures do
+        expect(partitioned_user.log_version).to eq 1
+
+        partitioned_user.update!(age: 25)
+
+        expect(partitioned_user.reload.log_version).to eq 2
+        expect(partitioned_user.log_data.versions.last.changes)
+          .to include("name" => "Partition User", "age" => 25, "active" => true)
+
+        partitioned_user.update!(age: 30)
+
+        expect(partitioned_user.reload.log_version).to eq 3
+        expect(partitioned_user.log_data.versions.last.changes)
+          .to include("age" => 30)
+        expect(partitioned_user.log_data.versions.last.changes.keys)
+          .not_to include("tittle", "active")
+      end
+    end
+
+    describe "timestamp_column is not set" do
+      let(:partitioned_user) { PartitionedUser.create!(age: 10, updated_at: Time.at(0)).reload }
+
+      it "uses 'updated_at' column if it exists", :aggregate_failures do
+        Timecop.freeze(Time.at(1_000_000)) do
+          partitioned_user.update!(age: 20)
+        end
+
+        expect(partitioned_user.reload).to use_timestamp(:updated_at)
       end
 
-      expect(post.reload.log_version).to eq 2
-      expect(post).to use_statement_timestamp
+      it "sets version timestamp to statement_timestamp() if 'updated_at' did not change", :aggregate_failures do
+        Timecop.freeze(Time.at(0)) do
+          partitioned_user.update!(age: 20)
+        end
+
+        expect(partitioned_user.reload).to use_statement_timestamp
+      end
     end
   end
 end

--- a/spec/integration/partition_spec.rb
+++ b/spec/integration/partition_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "acceptance_helper"
+
+describe "partition change imitation", :db do
+  include_context "cleanup migrations"
+
+  before(:all) do
+    Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
+      successfully "rails generate logidze:model post --after_trigger"
+      successfully "rake db:migrate"
+
+      # Close active connections to handle db variables
+      ActiveRecord::Base.connection_pool.disconnect!
+    end
+
+    Post.reset_column_information
+  end
+
+  describe "update" do
+    let(:initial_log_data) { Post.create!(title: "Partition Post", rating: 5, active: true).reload.log_data }
+
+    it "creates a new version like a full snapshot", :aggregate_failures do
+      post = Post.create!(title: "Partition Post", active: true, rating: 25, log_data: initial_log_data)
+
+      expect(post.reload.log_version).to eq 2
+      expect(post.log_data.versions.last.changes)
+        .to include("title" => "Partition Post", "rating" => 25, "active" => true)
+
+      post.update!(rating: 30)
+
+      expect(post.reload.log_version).to eq 3
+      expect(post.log_data.versions.last.changes)
+        .to include("rating" => 30)
+      expect(post.log_data.versions.last.changes.keys)
+        .not_to include("title", "active")
+    end
+  end
+
+  describe "timestamp_column is not set" do
+    let(:initial_log_data) { Post.create!(rating: 10, updated_at: Time.at(0)).reload.log_data }
+
+    it "uses 'updated_at' column if it exists", :aggregate_failures do
+      post = nil
+      Timecop.freeze(Time.at(1_000_000)) do
+        post = Post.create!(rating: 20, log_data: initial_log_data)
+      end
+
+      expect(post.reload.log_version).to eq 2
+      expect(post).to use_timestamp(:updated_at)
+    end
+
+    it "sets version timestamp to statement_timestamp() if 'updated_at' did not change", :aggregate_failures do
+      post = nil
+      Timecop.freeze(Time.at(0)) do
+        post = Post.create!(rating: 20, log_data: initial_log_data)
+      end
+
+      expect(post.reload.log_version).to eq 2
+      expect(post).to use_statement_timestamp
+    end
+  end
+end

--- a/spec/integration/timestamps_spec.rb
+++ b/spec/integration/timestamps_spec.rb
@@ -2,7 +2,7 @@
 
 require "acceptance_helper"
 
-describe "log timestamps", :db do
+shared_context "log_timestamps_context" do |generator_arg|
   before do
     Timecop.freeze(Time.at(1_000_000)) do
       post.update!(rating: 100)
@@ -21,9 +21,9 @@ describe "log timestamps", :db do
     before(:all) do
       Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
         # Post has an 'updated_at' column
-        successfully "rails generate logidze:model post"
+        successfully "rails generate logidze:model post #{generator_arg}"
         # User has a 'time' column
-        successfully "rails generate logidze:model user --only-trigger"
+        successfully "rails generate logidze:model user #{generator_arg} --only-trigger"
         successfully "rake db:migrate"
 
         # Close active connections to handle db variables
@@ -53,9 +53,9 @@ describe "log timestamps", :db do
       param = "--timestamp_column time"
       Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
         # Post has an 'updated_at' column
-        successfully "rails generate logidze:model post #{param}"
+        successfully "rails generate logidze:model post #{generator_arg} #{param}"
         # User has a 'time' column
-        successfully "rails generate logidze:model user --only-trigger #{param}"
+        successfully "rails generate logidze:model user #{generator_arg} --only-trigger #{param}"
         successfully "rake db:migrate"
 
         # Close active connections to handle db variables
@@ -77,9 +77,9 @@ describe "log timestamps", :db do
       param = "--timestamp_column nil"
       Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
         # Post has an 'updated_at' column
-        successfully "rails generate logidze:model post #{param}"
+        successfully "rails generate logidze:model post #{generator_arg} #{param}"
         # User has a 'time' column
-        successfully "rails generate logidze:model user --only-trigger #{param}"
+        successfully "rails generate logidze:model user #{generator_arg} --only-trigger #{param}"
         successfully "rake db:migrate"
 
         # Close active connections to handle db variables
@@ -91,5 +91,15 @@ describe "log timestamps", :db do
       expect(user).to use_statement_timestamp
       expect(user).to use_statement_timestamp
     end
+  end
+end
+
+describe "log timestamps", :db do
+  describe "before update or insert" do
+    include_context "log_timestamps_context"
+  end
+
+  describe "after update or insert" do
+    include_context "log_timestamps_context", "--after_trigger"
   end
 end

--- a/spec/integration/triggers_spec.rb
+++ b/spec/integration/triggers_spec.rb
@@ -2,13 +2,13 @@
 
 require "acceptance_helper"
 
-describe "triggers", :db do
+shared_context "triggers_context" do |generator_arg|
   include_context "cleanup migrations"
 
   before(:all) do
     @old_post = Post.create!(title: "First", rating: 100, active: true)
     Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
-      successfully "rails generate logidze:model post --limit 4 --backfill"
+      successfully "rails generate logidze:model post #{generator_arg} --limit 4 --backfill"
       successfully "rake db:migrate"
 
       # Close active connections to handle db variables
@@ -418,5 +418,15 @@ describe "triggers", :db do
       expect(post.log_data.versions.last.changes)
         .to include("title" => "Full me", "rating" => 22, "active" => true)
     end
+  end
+end
+
+describe "triggers", :db do
+  describe "before update or insert" do
+    include_context "triggers_context"
+  end
+
+  describe "after update or insert" do
+    include_context "triggers_context", "--after_trigger"
   end
 end

--- a/spec/logidze/utils/function_definitions_spec.rb
+++ b/spec/logidze/utils/function_definitions_spec.rb
@@ -9,6 +9,7 @@ describe Logidze::Utils::FunctionDefinitions do
 
     it "returns all library functions" do
       is_expected.to include(func_def("logidze_logger", 3, ""))
+      is_expected.to include(func_def("logidze_logger_after", 3, ""))
       is_expected.to include(func_def("logidze_snapshot", 3, "jsonb, text, text[], boolean"))
       is_expected.to include(func_def("logidze_filter_keys", 1, "jsonb, text[], boolean"))
       is_expected.to include(func_def("logidze_compact_history", 1, "jsonb, integer"))
@@ -22,6 +23,7 @@ describe Logidze::Utils::FunctionDefinitions do
 
     it "returns all functions from db without signatures" do
       is_expected.to include(func_def("logidze_logger", 3))
+      is_expected.to include(func_def("logidze_logger_after", 3))
       is_expected.to include(func_def("logidze_snapshot", 3))
       is_expected.to include(func_def("logidze_filter_keys", 1))
       is_expected.to include(func_def("logidze_compact_history", 1))

--- a/spec/support/postgres_helpers.rb
+++ b/spec/support/postgres_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Logidze
+  module PostgresHelpers #:nodoc:
+    def database_version
+      @database_version ||=
+        ::ActiveRecord::Base.connection.select_value("SELECT current_setting('server_version_num')::int;")
+    end
+
+    # server_version_num range
+    def skip_database_versions(versions)
+      skip("Skip for postgres versions #{versions}") if versions.include? database_version
+    end
+  end
+end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

<!--
  Otherwise, describe the changes:
-->

### What is the purpose of this pull request?
After trigger support [#215](https://github.com/palkan/logidze/issues/215)

### What changes did you make? (overview)
Add `--after_trigger` generator option.

### Is there anything you'd like reviewers to focus on?

Updating with a partition change calls INSERT trigger, so we don't have access to the OLD record.  In this case, we make a full snapshot (we can use previous versions to restore the state, but I'm not sure if that's a good idea).

I tried not to change the current integration tests and adapted them for both cases.

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [x] I've updated a documentation (Readme)
