### PR TITLE
Return nil when getting a version and there's no log_data

### DIFF
--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -114,6 +114,7 @@ module Logidze
 
     # Return a dirty copy of specified version of record
     def at_version(version)
+      return nil unless log_data
       return self if log_data.version == version
 
       log_entry = log_data.find_by_version(version)

--- a/spec/logidze/model_spec.rb
+++ b/spec/logidze/model_spec.rb
@@ -96,6 +96,11 @@ describe Logidze::Model, :db do
       expect(user_old.age).to eq 0
       expect(user_old.active).to eq true
     end
+
+    it "returns nil if log_data is nil" do
+      user.log_data = nil
+      expect(user.at(version: 1)).to be_nil
+    end
   end
 
   describe "#at!" do


### PR DESCRIPTION
### What is the purpose of this pull request?

Suggest a behavior change to the model's `#at` and `#at_version` methods (non-exclamation-mark versions).

### What changes did you make? (overview)

When using `#at(version: v)` or `#at_version(v)` to attempt to get a specific version of a model instance, but `log_data` hasn't been set yet, return `nil` instead of the current behavior.

The current behavior is to raise `NoMethodError` ("undefined method 'version' for nil:NilClass"). For the non-exclamation-point versions of these methods, I believe it is less surprising to instead get `nil`.

### Is there anything you'd like reviewers to focus on?

Please let me know if you like this idea, but would like some changes to this PR (such as actually mentioning this edge-case in the README.md).

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
