### PR TITLE
Add retrieving list of versions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add retrieving list of versions support. ([@tagirahmad][])
+
 - Add `--after-trigger` option to generate _after_ triggers for partitioned tables in older PostgreSQL versions. ([@SparLaimor][], [@prog-supdex][], [@palkan][])
 
 - **Breaking**. Ruby 2.7, Rails 6.0, PostgreSQL 10.0+ are required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,3 +385,4 @@ This is a quick fix for a more general problem (see [#59](https://github.com/pal
 [@miharekar]: https://github.com/miharekar
 [@prog-supdex]: https://github.com/prog-supdex
 [@SparLaimor]: https://github.com/SparLaimor
+[@tagirahmad]: https://github.com/tagirahmad

--- a/README.md
+++ b/README.md
@@ -257,6 +257,25 @@ Post.where(created_at: Time.zone.today.all_day).diff_from(time: 1.hour.ago)
 
 **NOTE:** If `log_data` is nil, `#diff_from` returns an empty Hash as `"changes"`.
 
+Also, it is possible to retrieve list of model's `versions`:
+
+```ruby
+post.versions # => Enumerator
+
+# you can use Enumerator's #take to return all
+post.versions.take
+
+# or you take a few or call any Enumerable method
+post.versions.take(2)
+post.versions.find do
+  _1.title == "old title"
+end
+
+# we can also add options
+post.versions(reverse: true) # from older to newer
+post.versions(include_self: true) # returns self as the first one (default) or the last one record (if reverse: true)
+```
+
 There are also `#undo!` and `#redo!` options (and more general `#switch_to!`):
 
 ```ruby

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -96,10 +96,16 @@ module Logidze
     end
 
     def logidze_versions(reverse: false, include_self: false)
-      versions_meta = reverse ? log_data.versions.reverse : log_data.versions
-      versions_meta = versions_meta.reject { _1.version == log_data.version } unless include_self
+      versions_meta = log_data.versions.dup
 
-      versions_meta.map { at(version: _1.version) }.to_enum
+      if reverse
+        versions_meta.reverse!
+        versions_meta.shift unless include_self
+      else
+        versions_meta.pop unless include_self
+      end
+
+      Enumerator.new { |yielder| versions_meta.each { yielder << at(version: _1.version) } }
     end
 
     # rubocop: enable Metrics/MethodLength

--- a/lib/logidze/model.rb
+++ b/lib/logidze/model.rb
@@ -94,6 +94,14 @@ module Logidze
 
       build_dup(log_entry, time)
     end
+
+    def logidze_versions(reverse: false, include_self: false)
+      versions_meta = reverse ? log_data.versions.reverse : log_data.versions
+      versions_meta = versions_meta.reject { _1.version == log_data.version } unless include_self
+
+      versions_meta.map { at(version: _1.version) }.to_enum
+    end
+
     # rubocop: enable Metrics/MethodLength
 
     # Revert record to the version at specified time (without saving to DB)

--- a/spec/logidze/model_spec.rb
+++ b/spec/logidze/model_spec.rb
@@ -103,6 +103,49 @@ describe Logidze::Model, :db do
     end
   end
 
+  describe "#logidze_versions" do
+    it "returns enumerator of versions" do
+      expect(user.logidze_versions).to be_a Enumerator
+    end
+
+    it "can take few versions" do
+      expect(user.logidze_versions.take(2)).to be_a Array
+      expect(user.logidze_versions.take(2).size).to eq 2
+      expect(user.logidze_versions.take(3).size).to eq 3
+    end
+
+    it "can find by attribute" do
+      expect(user.logidze_versions.find { _1.name == "test" }.log_version).to eq 3
+      expect(user.logidze_versions(include_self: true).find { _1.age == 10 }.log_version).to eq 5
+    end
+
+    context "when options are provided" do
+      it "returns versions except current version if include_self is false and reverse is true" do
+        expect(user.logidze_versions(reverse: true, include_self: false).to_a.size).to eq user.log_data.versions.size - 1
+        expect(user.logidze_versions(reverse: true, include_self: false).first)
+          .to eq user.at(version: user.log_data.versions[-2].version)
+      end
+
+      it "returns versions except current version if include_self is false and reverse is false" do
+        expect(user.logidze_versions(reverse: false, include_self: false).to_a.size).to eq user.log_data.versions.size - 1
+        expect(user.logidze_versions(reverse: false, include_self: false).first)
+          .to eq user.at(version: user.log_data.versions.first.version)
+      end
+
+      it "returns all the versions if include_self is true and current version is first if reverse is true" do
+        expect(user.logidze_versions(reverse: true, include_self: true).to_a.size).to eq user.log_data.versions.size
+        expect(user.logidze_versions(reverse: true, include_self: true).first)
+          .to eq user.at(version: user.log_data.versions.last.version)
+      end
+
+      it "returns all the versions if include_self is true and current version is last if reverse is false" do
+        expect(user.logidze_versions(reverse: false, include_self: true).to_a.size).to eq user.log_data.versions.size
+        expect(user.logidze_versions(reverse: false, include_self: true).to_a.last)
+          .to eq user.at(version: user.log_data.versions.last.version)
+      end
+    end
+  end
+
   describe "#at!" do
     it "update object in-place", :aggregate_failures do
       user.at!(time: time(350))


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

<!--
  Otherwise, describe the changes:
-->

### What is the purpose of this pull request?

Add retrieving [list of versions support](https://github.com/palkan/logidze/issues/212)

### What changes did you make? (overview)

Added `#logidze_versions` method which retrieves list of versions of model depending on options provided (`reverse` and `include_self`

If `reverse` is provided, reversed Enumerator will be returned.

If `include_self` is provided, the list will contain also current version of the model.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation (Readme)
