### PR TITLE
Replace #versions with #logidze_versions in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Add retrieving list of versions support. ([@tagirahmad][])
 
 ```ruby
-post.versions # => Enumerator
-post.versions.find do
+post.logidze_versions # => Enumerator
+post.logidze_versions.find do
   _1.title == "old title"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -260,20 +260,20 @@ Post.where(created_at: Time.zone.today.all_day).diff_from(time: 1.hour.ago)
 Also, it is possible to retrieve list of model's `versions`:
 
 ```ruby
-post.versions # => Enumerator
+post.logidze_versions # => Enumerator
 
 # you can use Enumerator's #take to return all
-post.versions.take
+post.logidze_versions.take
 
 # or you take a few or call any Enumerable method
-post.versions.take(2)
-post.versions.find do
+post.logidze_versions.take(2)
+post.logidze_versions.find do
   _1.title == "old title"
 end
 
 # we can also add options
-post.versions(reverse: true) # from older to newer
-post.versions(include_self: true) # returns self as the first one (default) or the last one record (if reverse: true)
+post.logidze_versions(reverse: true) # from older to newer
+post.logidze_versions(include_self: true) # returns self as the first one (default) or the last one record (if reverse: true)
 ```
 
 There are also `#undo!` and `#redo!` options (and more general `#switch_to!`):

--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ post.logidze_versions.find do
 end
 
 # we can also add options
-post.logidze_versions(reverse: true) # from older to newer
-post.logidze_versions(include_self: true) # returns self as the first one (default) or the last one record (if reverse: true)
+post.logidze_versions(reverse: true) # from newer to older
+post.logidze_versions(include_self: true) # returns self as the last record or the first one when `reverse` is set to true
 ```
 
 There are also `#undo!` and `#redo!` options (and more general `#switch_to!`):


### PR DESCRIPTION
Saw this today, and wanted to use it, and learned that README is all wrong 😅

It was implemented as `#logidze_versions` in #238.

And here are the results:

```
irb(main):043> cafe.logidze_versions.map{|v| v.log_version}
=> [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
irb(main):044> cafe.logidze_versions(reverse: true).map{|v| v.log_version}
=> [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
irb(main):045> cafe.logidze_versions(include_self: true).map{|v| v.log_version}
=> [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
irb(main):046> cafe.logidze_versions(reverse: true, include_self: true).map{|v| v.log_version}
=> [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
```

So most of the readme of this method is currently wrong 🙈

### What is the purpose of this pull request?

Fix README and CHANGELOG to be correct.

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [x] I've updated a documentation (Readme)
