### PR TITLE
Fix destroy not deleting `fx` trigger file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Fix `rails destroy logidze:model SomeModel` not deleting the `fx` trigger file file. ([@tylerhunt][])
+
 ## 1.3.0 (2024-01-09)
 
 - Add retrieving list of versions support. ([@tagirahmad][])
@@ -395,3 +397,4 @@ This is a quick fix for a more general problem (see [#59](https://github.com/pal
 [@prog-supdex]: https://github.com/prog-supdex
 [@SparLaimor]: https://github.com/SparLaimor
 [@tagirahmad]: https://github.com/tagirahmad
+[@tylerhunt]: https://github.com/tylerhunt

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -125,7 +125,8 @@ module Logidze
         end
 
         def next_version
-          previous_version&.next || 1
+          version = previous_version
+          (behavior == :invoke ? version&.next : version) || 1
         end
 
         def all_triggers

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -312,14 +312,36 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
       let(:path) { File.join(destination_root, "app", "models", "user.rb") }
       let(:base_args) { ["User", "--no-after-trigger"] }
 
-      it "deletes migration file it created" do
+      before do
         run_generator(args)
+      end
+
+      it "deletes migration file it created" do
         migration_file = migration_file("db/migrate/add_logidze_to_users.rb")
+
         expect(migration_file).to exist
 
-        Rails::Generators.invoke "logidze:model", args, behavior: :revoke, destination_root: destination_root
-        migration_file = migration_file("db/migrate/add_logidze_to_users.rb")
+        Rails::Generators.invoke "logidze:model", args,
+          behavior: :revoke,
+          destination_root: destination_root
+
         expect(migration_file).not_to exist
+      end
+
+      context "with fx" do
+        let(:fx_args) { use_fx_args }
+
+        it "deletes trigger file it created" do
+          trigger_file = file("db/triggers/logidze_on_users_v01.sql")
+
+          expect(trigger_file).to exist
+
+          Rails::Generators.invoke "logidze:model", args,
+            behavior: :revoke,
+            destination_root: destination_root
+
+          expect(trigger_file).not_to exist
+        end
       end
     end
   end


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix an issue where running `rails d logidze:model` doesn’t remove the `fx` trigger file since it was incrementing the trigger version and attempting the next version instead of the current version.

### What changes did you make? (overview)

Updated the `#next_version` method to return the current version when the task behavior is `:revoke`.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] ~I've updated a documentation (Readme)~
