### PR TITLE
support ordering of triggers by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Support sorting of trigger names alphabetically (defaults to false)
+
 ```ruby
 Logdize.sort_triggers_by_name = true
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+- Support sorting of trigger names alphabetically (defaults to false)
+```ruby
+Logdize.sort_triggers_by_name = true
+```
+
 ## 1.3.0 (2024-01-09)
 
 - Add retrieving list of versions support. ([@tagirahmad][])

--- a/README.md
+++ b/README.md
@@ -573,6 +573,15 @@ The `log_data` column has the following format:
 
 If you specify the limit in the trigger definition, then log size will not exceed the specified size. When a new change occurs, and there is no more room for it, the two oldest changes will be merged.
 
+## Ordering of Triggers in schema.rb
+
+By default, when generating `schema.rb`, Rails will order the triggers based on the id's of their respective tables. This can lead to unneccessary changes being made when utilizing `rails db:prepare`, since the ordering of the tables will now be based off the alphabetical ordering (see [#250](https://github.com/palkan/logidze/issues/250) for more details). To force the ordering to be consistent with `rails db:prepare`, logidze can be configured to order the triggers alphabetically.
+```ruby
+# config/initializers/logidze.rb
+
+Logidze.sort_triggers_by_name = true
+```
+
 ## Troubleshooting
 
 ### `log_data` is nil when using Rails fixtures

--- a/README.md
+++ b/README.md
@@ -575,7 +575,8 @@ If you specify the limit in the trigger definition, then log size will not excee
 
 ## Ordering of Triggers in schema.rb
 
-By default, when generating `schema.rb`, Rails will order the triggers based on the id's of their respective tables. This can lead to unneccessary changes being made when utilizing `rails db:prepare`, since the ordering of the tables will now be based off the alphabetical ordering (see [#250](https://github.com/palkan/logidze/issues/250) for more details). To force the ordering to be consistent with `rails db:prepare`, logidze can be configured to order the triggers alphabetically.
+By default, when generating `schema.rb`, Rails will order the triggers based on the id's of their respective tables. This can lead to unnecessary changes being made when utilizing `rails db:prepare`, since the ordering of the tables will now be based off the alphabetical ordering (see [#250](https://github.com/palkan/logidze/issues/250) for more details). To force the ordering to be consistent with `rails db:prepare`, Logidze can be configured to order the triggers alphabetically.
+
 ```ruby
 # config/initializers/logidze.rb
 

--- a/lib/logidze.rb
+++ b/lib/logidze.rb
@@ -25,6 +25,8 @@ module Logidze
     attr_accessor :ignore_log_data_by_default
     # Whether #at should return self or nil when log_data is nil
     attr_accessor :return_self_if_log_data_is_empty
+    # Determines if triggers are sorted by related table id or by name
+    attr_accessor :sort_triggers_by_name
     # Determines what Logidze should do when upgrade is needed (:raise | :warn | :ignore)
     attr_reader :on_pending_upgrade
 
@@ -68,4 +70,5 @@ module Logidze
   self.ignore_log_data_by_default = false
   self.return_self_if_log_data_is_empty = true
   self.on_pending_upgrade = :ignore
+  self.sort_triggers_by_name = :false
 end

--- a/lib/logidze.rb
+++ b/lib/logidze.rb
@@ -70,5 +70,5 @@ module Logidze
   self.ignore_log_data_by_default = false
   self.return_self_if_log_data_is_empty = true
   self.on_pending_upgrade = :ignore
-  self.sort_triggers_by_name = :false
+  self.sort_triggers_by_name = false
 end

--- a/lib/logidze/engine.rb
+++ b/lib/logidze/engine.rb
@@ -20,5 +20,18 @@ module Logidze
         end
       end
     end
+
+    initializer "sort triggers by name" do |app|
+      if config.logidze.sort_triggers_by_name
+        ActiveSupport.on_load(:active_record) do
+          require "fx/adapters/postgres/triggers"
+          Fx::Adapters::Postgres::Triggers.singleton_class.prepend(Module.new do
+            def all(*args)
+              super.sort_by(&:name)
+            end
+          end)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #250 

### What is the purpose of this pull request?
This PR allows for a configurable option to declare how the ordering of the triggers are generated as part of the schema dump.

### What changes did you make? (overview)
* added a configurable option for `Logdize.order_by_trigger_name` that defaults to `false`
* when set to true, a module is prepended `Fx::Adapters::Postgres::Triggers` to ensure the returned value is sorted by `name`

### Is there anything you'd like reviewers to focus on?
I'm not sure the best way to test this. I've tested my branch locally against an active project and this is resolving the issue I described.

### Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry 
- [x] I've updated a documentation (Readme)
