### PR TITLE
Fix Rspec workflow in CI, add Rails 8 to matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,59 +19,69 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1"]
-        postgres: ["12"]
+        ruby: ["3.4"]
+        postgres: ["16"]
         gemfile: [
-          "gemfiles/rails72.gemfile"
+          rails8.gemfile
         ]
         fx: ["false"]
         after_trigger: ["false"]
         include:
-        - ruby: "3.2"
+        - ruby: "3.4"
+          postgres: "16"
+          gemfile: rails8.gemfile
+          fx: "false"
+          after_trigger: "false"
+        - ruby: "3.3"
+          postgres: "16"
+          gemfile: rails8.gemfile
+          fx: "false"
+          after_trigger: "true"
+        - ruby: "3.3"
+          postgres: "16"
+          gemfile: rails72.gemfile
+          fx: "false"
+          after_trigger: "false"
+        - ruby: "3.3"
           postgres: "15"
-          gemfile: "gemfiles/railsmaster.gemfile"
+          gemfile: railsmaster.gemfile
           fx: "false"
           after_trigger: "false"
         - ruby: "3.2"
           postgres: "15"
-          gemfile: "gemfiles/rails72.gemfile"
+          gemfile: rails72.gemfile
           fx: "false"
           after_trigger: "false"
         - ruby: "3.2"
           postgres: "15"
-          gemfile: "gemfiles/rails71.gemfile"
+          gemfile: rails71.gemfile
           fx: "false"
           after_trigger: "false"
         - ruby: "3.2"
           postgres: "15"
-          gemfile: "gemfiles/rails70.gemfile"
+          gemfile: rails70.gemfile
           fx: "false"
           after_trigger: "false"
         - ruby: "3.1"
           postgres: "12"
-          gemfile: "gemfiles/rails72.gemfile"
+          gemfile: rails72.gemfile
           fx: "false"
           after_trigger: "true"
-        - ruby: "3.0"
-          postgres: "13"
-          gemfile: "gemfiles/rails72.gemfile"
-          fx: "false"
-          after_trigger: "false"
         - ruby: "2.7"
           postgres: "13"
-          gemfile: "gemfiles/rails6.gemfile"
+          gemfile: rails6.gemfile
           fx: "false"
           after_trigger: "false"
           table_name_prefix: 'prefix-'
           table_name_suffix: '-suffix'
         - ruby: "2.7"
           postgres: "11"
-          gemfile: "gemfiles/rails6.gemfile"
+          gemfile: rails6.gemfile
           fx: "false"
           after_trigger: "true"
         - ruby: "2.7"
           postgres: "10"
-          gemfile: "gemfiles/rails6.gemfile"
+          gemfile: rails6.gemfile
           fx: "false"
           after_trigger: "false"
     services:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -86,11 +86,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - uses: actions/checkout@v3
-    - name: Install system deps
-      run: |
-        sudo apt-get update
-        sudo apt-get -yqq install libpq-dev
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
       CI: true
       RAILS_ENV: test
       DATABASE_URL: postgres://postgres:postgres@localhost:5432

--- a/gemfiles/rails8.gemfile
+++ b/gemfiles/rails8.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+rails_version = '~> 8.0.0'
+gem 'railties', rails_version
+gem 'activerecord', rails_version
+
+eval_gemfile './shared.gemfile'
+
+gemspec path: '..'

--- a/logidze.gemspec
+++ b/logidze.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "rspec-rails", ">= 4.0"
   spec.add_development_dependency "timecop", "~> 0.8"
+  spec.add_development_dependency "concurrent-ruby", "1.3.4" # Remove once https://github.com/rails/rails/issues/54263 is resolved
 end


### PR DESCRIPTION
### What is the purpose of this pull request?
fd67403e265d3735d4dbe75bca4f06c2e886c7b1 fixes the Rspec matrix in CI - this [was broken in 2023](https://github.com/palkan/logidze/commit/d2f77afd3ca05d15b09738273bb3961d7d2bbc70#diff-1fadaba7942eb03a370984f465dc59789417e580083e4bcaa2d073959b1815beL100-L105), as the env variable to set the gemfile was added to other workflow files, but not the rsped one.

dfd2b2736cb827f096f695ff57e9c8c5c113e717 modernizes the workflow (no need to manually install libpq anymore)

83480a82ba86940d5674496b1e8855774b5f8aaa adds Rails 8 to the matrix and modernizes the ruby/postgres versions the gem is tested with.

77d350f11230f9c2673c6d940fdfee36fd62a385 is needed due to https://github.com/rails/rails/issues/54263, don't think it is desirable to merge.

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

The specs fail against Rails master, unsure how to fix atm.

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
