### PR TITLE
Provide bang versions of meta methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -418,3 +418,4 @@ This is a quick fix for a more general problem (see [#59](https://github.com/pal
 [@SparLaimor]: https://github.com/SparLaimor
 [@tagirahmad]: https://github.com/tagirahmad
 [@tylerhunt]: https://github.com/tylerhunt
+[@atomaka]: https://github.com/atomaka

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add block-less versions of `with_responsible` and `with_metata`. ([@atomaka][])
+
 ## 1.4.1 (2025-06-05)
 
 - Don't drop functions in the upgrade migration. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Other requirements:
   - [Basic API](#basic-api)
   - [Track meta information](#track-meta-information)
   - [Track responsibility](#track-responsibility)
+  - [Persisted metadata](#persisted-metadata)
   - [Disable logging temporary](#disable-logging-temporary)
   - [Reset log](#reset-log)
   - [Creating full snapshot instead of diffs](#full-snapshots)
@@ -409,6 +410,26 @@ Logidze.with_responsible(user.id, transactional: false) do
   post.save!
 end
 ```
+
+#### Persisted metadata
+
+You can also set metadata and responsibility that persists for the database connection using the bang versions of these methods:
+
+```ruby
+Logidze.with_meta!({ip: request.ip})
+post.save!
+
+Logidze.with_responsible!(user.id)
+post.save!
+```
+
+This persisted information needs to be explicitly cleared.
+
+```ruby
+Logidze.clear_meta!
+```
+
+**Important:** Persisted metadata is set at the connection level and will affect all subsequent operations on that connection until cleared. Always ensure you call `clear_meta!` when done, especially in web applications where connections are reused.
 
 ### Disable logging temporary
 

--- a/lib/logidze/meta.rb
+++ b/lib/logidze/meta.rb
@@ -36,10 +36,6 @@ module Logidze # :nodoc:
       with_meta!(meta)
     end
 
-    def clear_responsible!
-      clear_meta!
-    end
-
     class MetaBase # :nodoc:
       attr_reader :meta
 

--- a/lib/logidze/meta.rb
+++ b/lib/logidze/meta.rb
@@ -15,38 +15,38 @@ module Logidze # :nodoc:
       with_meta(meta, transactional: transactional, &block)
     end
 
-    class MetaWrapper # :nodoc:
-      def self.wrap_with(meta, &block)
-        new(meta, &block).perform
+    def with_meta!(meta)
+      return if meta.nil?
+
+      if Thread.current[:logidze_in_block]
+        raise StandardError, "with_meta! cannot be called from within a with_meta block"
       end
 
-      attr_reader :meta, :block
+      MetaForConnection.new(meta).set!
+    end
+
+    def clear_meta!
+      MetaForConnection.new({}).clear!
+    end
+
+    def with_responsible!(responsible_id)
+      return if responsible_id.nil?
+
+      meta = {Logidze::History::Version::META_RESPONSIBLE => responsible_id}
+      with_meta!(meta)
+    end
+
+    def clear_responsible!
+      clear_meta!
+    end
+
+    class MetaBase # :nodoc:
+      attr_reader :meta
 
       delegate :connection, to: ActiveRecord::Base
 
-      def initialize(meta, &block)
+      def initialize(meta)
         @meta = meta
-        @block = block
-      end
-
-      def perform
-        raise ArgumentError, "Block must be given" unless block
-        return block.call if meta.nil?
-
-        call_block_in_meta_context
-      end
-
-      def call_block_in_meta_context
-        prev_meta = current_meta
-
-        meta_stack.push(meta)
-
-        pg_set_meta_param(current_meta)
-        result = block.call
-        result
-      ensure
-        pg_reset_meta_param(prev_meta)
-        meta_stack.pop
       end
 
       def current_meta
@@ -68,6 +68,66 @@ module Logidze # :nodoc:
         else
           pg_set_meta_param(prev_meta)
         end
+      end
+    end
+
+    class MetaWrapper < MetaBase # :nodoc:
+      def self.wrap_with(meta, &block)
+        new(meta, &block).perform
+      end
+
+      attr_reader :block
+
+      def initialize(meta, &block)
+        super(meta)
+        @block = block
+      end
+
+      def perform
+        raise ArgumentError, "Block must be given" unless block
+        return block.call if meta.nil?
+
+        call_block_in_meta_context
+      end
+
+      def call_block_in_meta_context
+        prev_meta = current_meta
+        was_in_block = Thread.current[:logidze_in_block]
+
+        meta_stack.push(meta)
+        Thread.current[:logidze_in_block] = true
+
+        pg_set_meta_param(current_meta)
+        result = block.call
+        result
+      ensure
+        pg_reset_meta_param(prev_meta)
+        meta_stack.pop
+        Thread.current[:logidze_in_block] = was_in_block
+      end
+    end
+
+    class MetaForConnection < MetaBase # :nodoc:
+      def set!
+        return if meta.nil?
+
+        meta_stack.push(meta)
+        pg_set_meta_param(current_meta)
+      end
+
+      def clear!
+        meta_stack.clear
+        pg_clear_meta_param
+      end
+
+      private
+
+      def pg_set_meta_param(value)
+        connection.execute("SET logidze.meta = #{encode_meta(value)};")
+      end
+
+      def pg_clear_meta_param
+        connection.execute("SET logidze.meta TO DEFAULT;")
       end
     end
 
@@ -99,7 +159,9 @@ module Logidze # :nodoc:
       end
     end
 
+    private_constant :MetaBase
     private_constant :MetaWrapper
+    private_constant :MetaForConnection
     private_constant :MetaWithTransaction
     private_constant :MetaWithoutTransaction
   end

--- a/spec/integration/meta_spec.rb
+++ b/spec/integration/meta_spec.rb
@@ -383,7 +383,6 @@ describe "logs metadata", :db do
     after { Logidze.clear_meta! }
 
     context "setting meta for connection" do
-
       it "sets meta for connection and persists across operations" do
         Logidze.with_meta!(meta)
 
@@ -454,7 +453,7 @@ describe "logs metadata", :db do
         Logidze.with_meta!(meta)
 
         Logidze.with_responsible!(responsible.id)
-        expect(subject.reload.whodunnit).to eq (responsible)
+        expect(subject.reload.whodunnit).to eq(responsible)
         expect(subject.meta).to eq(meta.merge(
           Logidze::History::Version::META_RESPONSIBLE => responsible.id
         ))

--- a/spec/integration/meta_spec.rb
+++ b/spec/integration/meta_spec.rb
@@ -409,7 +409,7 @@ describe "logs metadata", :db do
 
     subject { User.create!(name: "test", age: 10, active: false) }
 
-    after { Logidze.clear_responsible! }
+    after { Logidze.clear_meta! }
 
     context "setting responsible for connection" do
       it "sets responsible for connection and persists across operations" do
@@ -427,12 +427,12 @@ describe "logs metadata", :db do
         expect(subject.reload.whodunnit).to be_nil
       end
 
-      it "can be cleared with clear_responsible!" do
+      it "can be cleared with clear_meta!" do
         Logidze.with_responsible!(responsible.id)
 
         expect(subject.reload.whodunnit).to eq(responsible)
 
-        Logidze.clear_responsible!
+        Logidze.clear_meta!
 
         subject.update!(age: 12)
         expect(subject.reload.whodunnit).to be_nil


### PR DESCRIPTION
Fixes #202

### What is the purpose of this pull request?

Provide `Logidze.with_meta!` and `Logidize.with_responsible!` to attach these details permanently instead of for the duration of a block.  This resolves #202 and allows the behavior outlined in #200:

```
console do
  Logidze.with_responsible(current_user.id)
end
```

It also considers feedback in the attempt from #203.

Finally, this resolves #221, although using this in web requests comes with its own risks.

### What changes did you make? (overview)

In `Logidze::Meta`

* New class `MetaBase` pulling meta stack management from `MetaWrapper`
* New class `MetaForConnection` to manage metadata for bang methods
* New method `.with_meta!` to set metadata with no implicit end
* New method `.with_responsible!` to set actor id with no implicit end
* New method `.clear_meta!` to explicitly clear metadata

### Is there anything you'd like reviewers to focus on?

I'm not sure how I feel about this implementation so I'm happy to revisit it if there are suggestions.  I believe i hit the use-cases missed in #203.

Changelog/Readme changes will be added after the approach has been established.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation (Readme)
