### PR TITLE
docs: fix detached mode example and add key missing notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,15 @@ bundle exec rails generate logidze:model Post --after-trigger
 ### Storing history data in a separate table
 
 By default, Logidze stores history data in the `log_data` column in the origin record table, which might lead to table bloat.
-If it concerns you, you may configure Logidze to store history data in a separate table by providing `--detached` option to the migration:
+If it concerns you, you may configure Logidze to store history data in a separate table instead.
 
+1. First, generate the shared `logidze_data` table (only once per project):
+
+```sh
+bundle exec rails generate logidze:migration:logs
+```
+
+2. Then, create your model migration with the --detached option:
 ```sh
 bundle exec rails generate logidze:model Post --detached
 ```

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ By default, Logidze stores history data in the `log_data` column in the origin r
 If it concerns you, you may configure Logidze to store history data in a separate table by providing `--detached` option to the migration:
 
 ```sh
-bundle exec rails logidze:model Post --detached
+bundle exec rails generate logidze:model Post --detached
 ```
 
 You can also configure Logidze to always store history data in a separate table for all models:
@@ -220,6 +220,8 @@ You can also configure Logidze to always store history data in a separate table 
 
 Logidze.log_data_placement = :detached
 ```
+
+**NOTE:** You may need to upgrade your `logdize_logger` function. Check [upgrading](https://github.com/palkan/logidze/tree/master?tab=readme-ov-file#upgrading) for more details
 
 **IMPORTANT:** Using `--detached` mode for storing historic data slightly decreases performance. Check [bench results] for the details.
 


### PR DESCRIPTION
This PR improves the documentation around the detached mode:

- **Fixes incorrect command**
The example now correctly uses `rails generate logidze:model` instead of the invalid `rails logidze:model`.

- **Adds missing note on logidze_data table**
Documents the migration step for creating the shared `logidze_data` table, which is required when using detached mode.

- **Adds note on upgrading logidze_logger**
Older versions of `logidze_logger` (e.g. `logidze_logger_v02`) do not support detached mode and raise errors like:

   ```
   ERROR:  record "old" has no field "log_data" (PG::UndefinedColumn)  
   CONTEXT: SQL expression "OLD.log_data is NULL OR OLD.log_data = '{}'::jsonb"  
   PL/pgSQL function logidze_logger() line 46 at IF  
   ```