### PR TITLE
Allow setting a default history size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Add `Logidze.default_history_size_limit` configuration option to set a default history size limit for newly generated triggers. ([@gabo-cs][])
+
 - Add block-less versions of `with_responsible` and `with_metata`. ([@atomaka][])
 
 ## 1.4.1 (2025-06-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,3 +421,4 @@ This is a quick fix for a more general problem (see [#59](https://github.com/pal
 [@tagirahmad]: https://github.com/tagirahmad
 [@tylerhunt]: https://github.com/tylerhunt
 [@atomaka]: https://github.com/atomaka
+[@gabo-cs]: https://github.com/gabo-cs

--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ You can provide the `limit` option to `generate` to limit the size of the log (b
 bundle exec rails generate logidze:model Post --limit=10
 ```
 
+You can also set a default limit globally so that every generated trigger uses it automatically:
+
+```ruby
+# config/initializers/logidze.rb
+Logidze.default_history_size_limit = 100
+```
+
+The explicit `--limit` flag still takes precedence when passed.
+
 ### Tracking only selected columns
 
 You can log only particular columns changes. There are mutually exclusive `except` and `only` options for this:

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -91,7 +91,7 @@ module Logidze
         end
 
         def limit
-          options[:limit]
+          options[:limit] || Logidze.default_history_size_limit
         end
 
         def backfill?

--- a/lib/logidze.rb
+++ b/lib/logidze.rb
@@ -30,6 +30,9 @@ module Logidze
     attr_accessor :sort_triggers_by_name
     # Determines what Logidze should do when upgrade is needed (:raise | :warn | :ignore)
     attr_reader :on_pending_upgrade
+    # Sets the default history size limit for newly generated triggers.
+    # When set, the generator uses this value unless --limit is explicitly passed.
+    attr_accessor :default_history_size_limit
     # Determines where to store +log_data+:
     # - +:inline+ - force Logidze to store it in the origin table in the +log_data+ column
     # - +:detached+ - force Logidze to  store it in the +logidze_data+ table in the +log_data+ column
@@ -86,5 +89,6 @@ module Logidze
   self.return_self_if_log_data_is_empty = true
   self.on_pending_upgrade = :ignore
   self.sort_triggers_by_name = false
+  self.default_history_size_limit = nil
   self.log_data_placement = nil
 end

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -118,6 +118,29 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         end
       end
 
+      context "with default_history_size_limit" do
+        around do |example|
+          old_value = Logidze.default_history_size_limit
+          Logidze.default_history_size_limit = 100
+          example.run
+          Logidze.default_history_size_limit = old_value
+        end
+
+        it "uses the configured default when --limit is not passed" do
+          is_expected.to be_a_file
+          is_expected.to contain(/execute procedure logidze_logger\(100, 'updated_at'\);/i)
+        end
+
+        context "when --limit is explicitly passed" do
+          let(:base_args) { ["user", "--limit=5", "--no-after-trigger"] }
+
+          it "prefers the explicit --limit over the default" do
+            is_expected.to be_a_file
+            is_expected.to contain(/execute procedure logidze_logger\(5, 'updated_at'\);/i)
+          end
+        end
+      end
+
       context "with debounce_time" do
         let(:base_args) { ["user", "--debounce_time=5000", "--no-after-trigger"] }
 


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

<!--
  Otherwise, describe the changes:
-->

### What is the purpose of this pull request?

When adding Logidze to a new model, the `--limit` flag on the generator defaults to `null` (unlimited history). In practice, most teams settle on a standard limit to prevent unbounded `log_data` growth, but it's easy to forget to pass `--limit` on every generator invocation. 

This adds a `Logidze.default_history_size_limit` configuration option so teams can set their preferred limit once in an initializer and have it applied automatically to every new trigger. 
                                                                                    
```ruby                                                                           
# config/initializers/logidze.rb
Logidze.default_history_size_limit = 100
```
The explicit `--limit` flag still takes precedence when passed.                     
                                      
###  What changes did you make? (overview)                                             
                                                                                  
  - `lib/logidze.rb` — Added `default_history_size_limit` attr_accessor (defaults to `nil`, preserving current behavior)
  - `lib/generators/logidze/model/model_generator.rb` — limit method falls back to `Logidze.default_history_size_limit` when `options[:limit]` is not set
  - `CHANGELOG.md` — Added entry under `master (unreleased)`
  - `README.md` — Documented the new option in the "Log size limits" section                                                                           
                                                      
### Is there anything you'd like reviewers to focus on?                               
                                                                                  
The fallback logic is a single line change (`options[:limit] || Logidze.default_history_size_limit`). The main question is whether this is the right place for the default — the alternative would be setting it as a `class_option default:` on the generator, but reading from `Logidze.*` follows the existing pattern used by `detached?` → `Logidze.detached_log_placement?`.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation (Readme)
