### PR TITLE
Fix RuboCop Style/ModuleMemberExistenceCheck offense

### DIFF
--- a/lib/logidze/versioned_association.rb
+++ b/lib/logidze/versioned_association.rb
@@ -2,7 +2,7 @@
 
 # `inversed` attr_accessor has been removed in Rails 5.2.1
 # See https://github.com/rails/rails/commit/39e57daffb9ff24726b1e86dfacf76836dd0637b#diff-c47e1c26ae8a3d486119e0cc91f40a30
-unless ::ActiveRecord::Associations::Association.instance_methods.include?(:inversed)
+unless ::ActiveRecord::Associations::Association.method_defined?(:inversed)
   using(Module.new do
     refine ::ActiveRecord::Associations::Association do
       attr_reader :inversed


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

<!--
  Otherwise, describe the changes:
-->

### What is the purpose of this pull request?
                                                                                                               
The CI RuboCop check currently [fails](https://github.com/palkan/logidze/actions/runs/24567772403/job/71832391347?pr=267) on `master` due to a `Style/ModuleMemberExistenceCheck` offense in `lib/logidze/versioned_association.rb`. This one-liner fix unblocks the lint job for all PRs.

### What changes did you make? (overview)

Replaced `instance_methods.include?(:inversed)` with the idiomatic `method_defined?(:inversed)` — same behavior, just the form RuboCop expects.

### Is there anything you'd like reviewers to focus on?

Nothing — it's a single-method substitution with identical semantics.

### Checklist
  - [ ] I've added tests for this change 
  - [ ] I've added a Changelog entry
  - [ ] I've updated a documentation (Readme)

N/A — no behavioral change, just a style fix.