### PR TITLE
Add optional delete tracking in detached mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## master (unreleased)
 
+- Add `track_deletes` option to preserve `log_data` after a record is physically
+  deleted and append a deletion version capturing who / when. Only supported
+  with detached log placement. Enable via `Logidze.track_deletes = true`,
+  `has_logidze detached: true, track_deletes: true`, or
+  `rails g logidze:model Post --track-deletes`. The deletion version has a
+  top-level `_d: true` marker, and the `has_one :logidze_data` association no
+  longer uses `dependent: :destroy` when the feature is enabled.
+
+  Bumps `logidze_logger` function to version 6. Existing installations should
+  run `rails g logidze:install --update` to upgrade the function before using
+  the new feature.
+
 - Add block-less versions of `with_responsible` and `with_metata`. ([@atomaka][])
 
 ## 1.4.1 (2025-06-05)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Other requirements:
   - [Undoing a Generated Invocation](#undoing-a-generated-invocation)
   - [Using with partitioned tables](#using-with-partitioned-tables)
   - [Storing history data in a separate table](#storing-history-data-in-a-separate-table)
+    - [Tracking deletes](#tracking-deletes)
 - [Usage](#usage)
   - [Basic API](#basic-api)
   - [Track meta information](#track-meta-information)
@@ -233,6 +234,85 @@ Logidze.log_data_placement = :detached
 **NOTE:** You may need to upgrade your `logdize_logger` function. Check [upgrading](https://github.com/palkan/logidze/tree/master?tab=readme-ov-file#upgrading) for more details
 
 **IMPORTANT:** Using `--detached` mode for storing historic data slightly decreases performance. Check [bench results] for the details.
+
+#### Tracking deletes
+
+When using `--detached`, you can also ask Logidze to preserve `log_data` after
+the origin record is physically deleted and append a final "deletion" version
+that captures _who_ and _when_ (via the usual `Logidze.with_responsible` /
+`Logidze.with_meta` helpers). This gives you a lightweight, DB-level audit trail
+for deletions without adopting a soft-delete pattern.
+
+The usual alternative — adding a `deleted_at` column via `paranoia`, `discard`,
+or a hand-rolled flag — works, but has well-known tradeoffs: every query has to
+remember to filter `WHERE deleted_at IS NULL` (and miss-filtering is a common
+source of data-leak bugs), indexes and foreign-key semantics have to account
+for the extra state, and the table accumulates rows indefinitely which can
+bloat storage and slow down queries over time. Delete tracking in Logidze
+sidesteps all of this: the row is physically gone from the tracked table and
+the audit trail lives on the `logidze_data` side.
+
+> **Note:** "soft delete" as an audit mechanism is not the same thing as a
+> user-facing _deactivated_ / _paused_ / _archived_ state, even though people
+> sometimes conflate the two. Those are real domain states that belong on the
+> model as their own column(s) with their own queries; they should not be
+> reused to mean "deleted". This feature is strictly for the audit-trail case.
+
+```sh
+bundle exec rails generate logidze:model Post --track-deletes
+```
+
+`--track-deletes` implies `--detached`. You can also enable it globally:
+
+```ruby
+# config/initializers/logidze.rb
+
+Logidze.log_data_placement = :detached
+Logidze.track_deletes = true
+```
+
+Or per-model:
+
+```ruby
+class Post < ApplicationRecord
+  has_logidze detached: true, track_deletes: true
+end
+```
+
+When enabled:
+
+- The generated trigger fires on `INSERT`, `UPDATE`, and `DELETE`.
+- On `DELETE`, a new version is appended to the retained `logidze_data.log_data`
+  with:
+  - `c` — an empty diff (`{}`), since no columns changed at delete time
+  - `m` — the current `Logidze.with_meta` / `Logidze.with_responsible` payload (if any)
+  - `_d: true` — a top-level marker identifying the version as a deletion
+- The `has_one :logidze_data` association is declared **without** `dependent: :destroy`
+  so the log survives the origin record.
+- Deletes cascaded via `ON DELETE CASCADE` are captured just like direct deletes —
+  the trigger fires regardless of how the row is removed.
+
+```ruby
+post = Post.create!(title: "Hello")
+Logidze.with_responsible(current_user.id) { post.destroy! }
+
+data = Logidze::LogidzeData.find_by!(loggable_type: "Post", loggable_id: post.id)
+data.log_data.versions.last.data["_d"]         # => true
+data.log_data.versions.last.responsible_id     # => current_user.id
+```
+
+**IMPORTANT — do not reuse ids.** The `logidze_data` table identifies rows by
+`(loggable_type, loggable_id)`. If a new record is inserted with the same id as
+a previously-deleted one, its history will be appended to the deleted record's
+history rather than starting fresh — the two are indistinguishable to Logidze.
+Make sure your models never reuse ids (e.g. use monotonically increasing
+sequences or UUIDs). This matters for any Logidze-tracked detached model, but
+it's especially important when `track_deletes` is enabled, since deleted logs
+are retained indefinitely and become available targets for id collisions.
+
+**NOTE:** Tracking deletes only makes sense with detached log placement; in
+inline mode the `log_data` column is physically removed with the row. Passing
+`track_deletes: true` without detached mode raises `ArgumentError`.
 
 ## Usage
 

--- a/lib/generators/logidze/install/functions/logidze_logger.sql
+++ b/lib/generators/logidze/install/functions/logidze_logger.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION logidze_logger() RETURNS TRIGGER AS $body$
-  -- version: 5
+  -- version: 6
   DECLARE
     changes jsonb;
     version jsonb;
@@ -41,6 +41,53 @@ CREATE OR REPLACE FUNCTION logidze_logger() RETURNS TRIGGER AS $body$
     include_columns := NULLIF(TG_ARGV[3], 'null');
     detached_loggable_type := NULLIF(TG_ARGV[5], 'null');
     log_data_table_name := NULLIF(TG_ARGV[6], 'null');
+
+    -- Handle DELETE separately: append a "deletion" version (marked with top-level `_d: true`)
+    -- to the retained +logidze_data+ row. Only meaningful in detached mode: in inline mode
+    -- the +log_data+ column disappears with the row, so there is nothing to preserve.
+    IF TG_OP = 'DELETE' THEN
+      IF detached_loggable_type IS NULL THEN
+        RETURN OLD;
+      END IF;
+
+      EXECUTE format(
+        'SELECT ldtn.log_data FROM %I ldtn ' ||
+        'WHERE ldtn.loggable_type = $1 AND ldtn.loggable_id = $2 LIMIT 1',
+        log_data_table_name
+      ) USING detached_loggable_type, OLD.id INTO detached_log_data;
+
+      IF detached_log_data IS NULL OR detached_log_data = '{}'::jsonb THEN
+        -- No prior log: seed from OLD so the deletion version has context.
+        IF columns IS NOT NULL THEN
+          log_data := logidze_snapshot(to_jsonb(OLD.*), ts_column, columns, include_columns);
+        ELSE
+          log_data := logidze_snapshot(to_jsonb(OLD.*), ts_column);
+        END IF;
+      ELSE
+        log_data := detached_log_data;
+      END IF;
+
+      new_v := (log_data#>>'{h,-1,v}')::int + 1;
+      size := jsonb_array_length(log_data->'h');
+      version := logidze_version(new_v, '{}'::jsonb, statement_timestamp());
+      version := jsonb_set(version, '{_d}', 'true'::jsonb);
+
+      log_data := jsonb_set(log_data, ARRAY['h', size::text], version, true);
+      log_data := jsonb_set(log_data, '{v}', to_jsonb(new_v));
+
+      history_limit := NULLIF(TG_ARGV[0], 'null');
+      IF history_limit IS NOT NULL AND history_limit <= size THEN
+        log_data := logidze_compact_history(log_data, size - history_limit + 1);
+      END IF;
+
+      EXECUTE format(
+        'INSERT INTO %I(log_data, loggable_type, loggable_id) VALUES ($1, $2, $3) ' ||
+        'ON CONFLICT (loggable_type, loggable_id) DO UPDATE SET log_data = EXCLUDED.log_data',
+        log_data_table_name
+      ) USING log_data, detached_loggable_type, OLD.id;
+
+      RETURN OLD;
+    END IF;
 
     -- getting previous log_data if it exists for detached `log_data` storage variant
     IF detached_loggable_type IS NOT NULL
@@ -266,7 +313,11 @@ CREATE OR REPLACE FUNCTION logidze_logger() RETURNS TRIGGER AS $body$
       );
       err_captured = logidze_capture_exception(err_jsonb);
       IF err_captured THEN
-        return NEW;
+        IF TG_OP = 'DELETE' THEN
+          return OLD;
+        ELSE
+          return NEW;
+        END IF;
       ELSE
         RAISE;
       END IF;

--- a/lib/generators/logidze/install/functions/logidze_logger_after.sql
+++ b/lib/generators/logidze/install/functions/logidze_logger_after.sql
@@ -1,3 +1,3 @@
 CREATE OR REPLACE FUNCTION logidze_logger_after() RETURNS TRIGGER AS $body$
-  -- version: 5
+  -- version: 6
 <%= generate_logidze_logger_after %>

--- a/lib/generators/logidze/model/model_generator.rb
+++ b/lib/generators/logidze/model/model_generator.rb
@@ -17,6 +17,10 @@ module Logidze
       class_option :detached, type: :boolean, optional: true,
         desc: "Store history data in a separate table"
 
+      class_option :track_deletes, type: :boolean, optional: true,
+        desc: "Keep history data after the origin record is physically deleted " \
+          "and append a deletion version (implies --detached)"
+
       class_option :limit, type: :numeric, optional: true, desc: "Specify history size limit"
 
       class_option :debounce_time, type: :numeric, optional: true,
@@ -63,7 +67,13 @@ module Logidze
         return if update?
 
         indents = "  " * (class_name.scan("::").count + 1)
-        macros_name = detached? ? "has_logidze detached: true\n" : "has_logidze\n"
+        macros_name = if track_deletes?
+          "has_logidze detached: true, track_deletes: true\n"
+        elsif detached?
+          "has_logidze detached: true\n"
+        else
+          "has_logidze\n"
+        end
 
         if File.readlines("#{destination_root}/#{model_file_path}").grep(/has_logidze/).empty?
           inject_into_class(model_file_path, class_name.demodulize, indents + macros_name)
@@ -99,7 +109,11 @@ module Logidze
         end
 
         def detached?
-          options[:detached] || Logidze.detached_log_placement?
+          options[:detached] || track_deletes? || Logidze.detached_log_placement?
+        end
+
+        def track_deletes?
+          options[:track_deletes] || Logidze.track_deletes
         end
 
         def only_trigger?

--- a/lib/generators/logidze/model/triggers/logidze.sql
+++ b/lib/generators/logidze/model/triggers/logidze.sql
@@ -1,5 +1,5 @@
 CREATE TRIGGER <%= %Q("logidze_on_#{full_table_name}") %>
-BEFORE UPDATE OR INSERT ON <%= %Q("#{full_table_name}") %> FOR EACH ROW
+BEFORE UPDATE OR INSERT<% if track_deletes? %> OR DELETE<% end %> ON <%= %Q("#{full_table_name}") %> FOR EACH ROW
 WHEN (coalesce(current_setting('logidze.disabled', true), '') <> 'on')
 -- Parameters: history_size_limit (integer), timestamp_column (text), filtered_columns (text[]),
 -- include_columns (boolean), debounce_time_ms (integer), detached_loggable_type(text), log_data_table_name(text)

--- a/lib/generators/logidze/model/triggers/logidze_after.sql
+++ b/lib/generators/logidze/model/triggers/logidze_after.sql
@@ -1,5 +1,5 @@
 CREATE TRIGGER <%= %Q("logidze_on_#{full_table_name}") %>
-AFTER UPDATE OR INSERT ON <%= %Q("#{full_table_name}") %> FOR EACH ROW
+AFTER UPDATE OR INSERT<% if track_deletes? %> OR DELETE<% end %> ON <%= %Q("#{full_table_name}") %> FOR EACH ROW
 WHEN (coalesce(current_setting('logidze.disabled', true), '') <> 'on' AND pg_trigger_depth() < 1)
 -- Parameters: history_size_limit (integer), timestamp_column (text), filtered_columns (text[]),
 -- include_columns (boolean), debounce_time_ms (integer), detached_loggable_type(text), log_data_table_name(text)

--- a/lib/logidze.rb
+++ b/lib/logidze.rb
@@ -36,6 +36,11 @@ module Logidze
     #
     # By default we do not set +log_data_placement+ value and rely on `has_logidze` macros
     attr_accessor :log_data_placement
+    # Determines whether to keep +log_data+ after the origin record is physically deleted
+    # and append a "deletion" version capturing +who+ / +when+ of the delete.
+    #
+    # Requires +log_data_placement+ to be +:detached+.
+    attr_accessor :track_deletes
 
     # Temporary disable DB triggers.
     #
@@ -87,4 +92,5 @@ module Logidze
   self.on_pending_upgrade = :ignore
   self.sort_triggers_by_name = false
   self.log_data_placement = nil
+  self.track_deletes = false
 end

--- a/lib/logidze/detachable.rb
+++ b/lib/logidze/detachable.rb
@@ -5,8 +5,6 @@ module Logidze
     extend ActiveSupport::Concern
 
     included do
-      has_one :logidze_data, as: :loggable, class_name: "::Logidze::LogidzeData", dependent: :destroy, autosave: true
-
       delegate :log_data, to: :logidze_data, allow_nil: true
     end
 

--- a/lib/logidze/has_logidze.rb
+++ b/lib/logidze/has_logidze.rb
@@ -9,14 +9,37 @@ module Logidze
 
     module ClassMethods # :nodoc:
       # Include methods to work with history.
-      def has_logidze(ignore_log_data: Logidze.ignore_log_data_by_default, detached: Logidze.detached_log_placement?)
+      def has_logidze(ignore_log_data: Logidze.ignore_log_data_by_default,
+        detached: Logidze.detached_log_placement?,
+        track_deletes: Logidze.track_deletes)
         include Logidze::IgnoreLogData
         include Logidze::Model
 
-        if detached && !Logidze.inline_log_placement?
+        detached_mode = detached && !Logidze.inline_log_placement?
+
+        if track_deletes && !detached_mode
+          raise ArgumentError,
+            "`track_deletes: true` requires detached log placement " \
+            "(pass `detached: true` or set `Logidze.log_data_placement = :detached`)"
+        end
+
+        if detached_mode
           # Adds needed behavior to models and alters behavior of some methods from +Logidze::Model+ to
           # work with detached table for `log_data`
           include Logidze::Detachable
+
+          logidze_data_options = {
+            as: :loggable,
+            class_name: "::Logidze::LogidzeData",
+            autosave: true
+          }
+          # When `track_deletes` is enabled we intentionally do NOT use
+          # `dependent: :destroy` so the `logidze_data` row survives after the
+          # origin record is physically deleted. The DB trigger then appends
+          # a deletion version to the retained log.
+          logidze_data_options[:dependent] = :destroy unless track_deletes
+
+          has_one :logidze_data, **logidze_data_options
         end
 
         @ignore_log_data = ignore_log_data

--- a/spec/dummy/app/models/trashable.rb
+++ b/spec/dummy/app/models/trashable.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Trashable < ActiveRecord::Base
+  has_logidze detached: true, track_deletes: true
+end

--- a/spec/dummy/db/migrate/20250424000000_create_trashables.rb
+++ b/spec/dummy/db/migrate/20250424000000_create_trashables.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateTrashables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :trashables do |t|
+      t.string :name
+      t.integer :rating
+      t.boolean :active, default: true
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -42,8 +42,8 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
 
         is_expected.to be_a_file
         is_expected.to contain "ActiveRecord::Migration[#{ar_version}]"
-        is_expected.to contain("create_function :logidze_logger, version: 5")
-        is_expected.to contain("create_function :logidze_logger_after, version: 5")
+        is_expected.to contain("create_function :logidze_logger, version: 6")
+        is_expected.to contain("create_function :logidze_logger_after, version: 6")
         is_expected.to contain("create_function :logidze_snapshot, version: 3")
         is_expected.to contain("create_function :logidze_version, version: 2")
         is_expected.to contain("create_function :logidze_filter_keys, version: 1")
@@ -56,8 +56,8 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
 
         is_expected.to be_a_file
         %w[
-          logidze_logger_v05.sql
-          logidze_logger_after_v05.sql
+          logidze_logger_v06.sql
+          logidze_logger_after_v06.sql
           logidze_version_v02.sql
           logidze_filter_keys_v01.sql
           logidze_snapshot_v03.sql
@@ -146,10 +146,10 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
         is_expected.not_to contain("create_function :logidze_filter_keys")
         is_expected.to contain("create_function :logidze_compact_history, version: 1")
 
-        is_expected.to contain("create_function :logidze_logger, version: 5")
+        is_expected.to contain("create_function :logidze_logger, version: 6")
         is_expected.to contain("create_function :logidze_logger, version: 7")
 
-        is_expected.to contain("create_function :logidze_logger_after, version: 5")
+        is_expected.to contain("create_function :logidze_logger_after, version: 6")
         is_expected.to contain("create_function :logidze_logger_after, version: 7")
 
         is_expected.to contain("create_function :logidze_capture_exception")
@@ -160,8 +160,8 @@ describe Logidze::Generators::InstallGenerator, type: :generator do
 
         is_expected.to be_a_file
         %w[
-          logidze_logger_v05.sql
-          logidze_logger_after_v05.sql
+          logidze_logger_v06.sql
+          logidze_logger_after_v06.sql
           logidze_version_v02.sql
           logidze_snapshot_v03.sql
           logidze_compact_history_v01.sql

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -95,6 +95,19 @@ describe Logidze::Generators::ModelGenerator, type: :generator do
         end
       end
 
+      context "with track_deletes" do
+        let(:base_args) { ["user", "--no-after-trigger", "--track-deletes"] }
+
+        it "creates a migration with INSERT/UPDATE/DELETE trigger and injects macro", :aggregate_failures do
+          is_expected.to be_a_file
+          is_expected.to contain(/before update or insert or delete on "#{full_table_name("users")}" for each row/i)
+          is_expected.to contain(/execute procedure logidze_logger\(null, 'updated_at', null, null, null, 'User', #{Logidze::LogidzeData.quoted_table_name}\);/i)
+          is_expected.not_to contain "add_column :users, :log_data, :jsonb"
+
+          expect(file("app/models/user.rb")).to contain "has_logidze detached: true, track_deletes: true"
+        end
+      end
+
       context "with fx" do
         let(:fx_args) { use_fx_args }
 

--- a/spec/integration/track_deletes_spec.rb
+++ b/spec/integration/track_deletes_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "acceptance_helper"
+
+describe "track_deletes", :db, skip: !LOGIDZE_DETACHED do
+  include_context "cleanup migrations"
+
+  before(:all) do
+    Dir.chdir("#{File.dirname(__FILE__)}/../dummy") do
+      successfully "rails generate logidze:model trashable --track-deletes"
+      successfully "rake db:migrate"
+
+      # Close active connections to handle db variables
+      ActiveRecord::Base.connection_pool.disconnect!
+    end
+
+    Trashable.reset_column_information
+  end
+
+  let!(:trashable) { Trashable.create!(name: "Delete Me", rating: 10) }
+
+  describe "#destroy!" do
+    it "keeps the logidze_data row and appends a deletion version" do
+      trashable.update!(rating: 20)
+      expect(trashable.reload.log_version).to eq 2
+
+      trashable.destroy!
+
+      data = Logidze::LogidzeData.find_by!(
+        loggable_type: "Trashable",
+        loggable_id: trashable.id
+      )
+
+      expect(data.log_data).to be_a(Logidze::History)
+      expect(data.log_data.version).to eq 3
+
+      last = data.log_data.versions.last
+      expect(last.data["_d"]).to be true
+      expect(last.changes).to eq({})
+    end
+
+    it "captures responsible and meta on the deletion version" do
+      Logidze.with_responsible(42) do
+        Logidze.with_meta({"reason" => "gdpr"}) do
+          trashable.destroy!
+        end
+      end
+
+      data = Logidze::LogidzeData.find_by!(
+        loggable_type: "Trashable",
+        loggable_id: trashable.id
+      )
+
+      last = data.log_data.versions.last
+      expect(last.data["_d"]).to be true
+      expect(last.responsible_id).to eq 42
+      expect(last.meta).to include("reason" => "gdpr")
+    end
+
+    it "does not create a deletion version when logging is disabled" do
+      expect {
+        Logidze.without_logging { trashable.destroy! }
+      }.not_to change {
+        Logidze::LogidzeData.where(
+          loggable_type: "Trashable",
+          loggable_id: trashable.id
+        ).first&.log_data&.version
+      }
+    end
+  end
+
+  describe "with no prior log_data" do
+    it "seeds a snapshot from OLD and appends a deletion version" do
+      # Wipe log_data so the delete trigger has no prior state.
+      trashable.reset_log_data
+      expect(trashable.reload.log_data).to be_nil
+
+      trashable.destroy!
+
+      data = Logidze::LogidzeData.find_by!(
+        loggable_type: "Trashable",
+        loggable_id: trashable.id
+      )
+      expect(data.log_data.version).to eq 2
+      expect(data.log_data.versions.first.changes).to include("name" => "Delete Me")
+      expect(data.log_data.versions.last.data["_d"]).to be true
+    end
+  end
+
+  describe "has_logidze without track_deletes" do
+    it "raises when combined with inline log placement" do
+      expect {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "posts"
+          has_logidze detached: false, track_deletes: true
+        end
+      }.to raise_error(ArgumentError, /detached log placement/)
+    end
+  end
+end

--- a/spec/logidze/utils/function_definitions_spec.rb
+++ b/spec/logidze/utils/function_definitions_spec.rb
@@ -8,8 +8,8 @@ describe Logidze::Utils::FunctionDefinitions do
     subject { described_class.from_fs }
 
     it "returns all library functions" do
-      is_expected.to include(func_def("logidze_logger", 5, ""))
-      is_expected.to include(func_def("logidze_logger_after", 5, ""))
+      is_expected.to include(func_def("logidze_logger", 6, ""))
+      is_expected.to include(func_def("logidze_logger_after", 6, ""))
       is_expected.to include(func_def("logidze_snapshot", 3, "jsonb, text, text[], boolean"))
       is_expected.to include(func_def("logidze_filter_keys", 1, "jsonb, text[], boolean"))
       is_expected.to include(func_def("logidze_compact_history", 1, "jsonb, integer"))
@@ -22,8 +22,8 @@ describe Logidze::Utils::FunctionDefinitions do
     subject { described_class.from_db }
 
     it "returns all functions from db without signatures" do
-      is_expected.to include(func_def("logidze_logger", 5))
-      is_expected.to include(func_def("logidze_logger_after", 5))
+      is_expected.to include(func_def("logidze_logger", 6))
+      is_expected.to include(func_def("logidze_logger_after", 6))
       is_expected.to include(func_def("logidze_snapshot", 3))
       is_expected.to include(func_def("logidze_filter_keys", 1))
       is_expected.to include(func_def("logidze_compact_history", 1))


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!
-->

Currently, we are using the inline mode but also need to track deletes. Thus, we are utilizing the soft-delete pattern. Since we are starting to experience the table bloat problem, we are looking to migrate to the detach mode. The detach mode would also allow for logidze to track deletes without needing to rely of soft-deletes. This PR extends the detach mode to also track deletes with the need for soft-deletes. 

Yes, Devin AI did most of the coding, but I was involved in defining the problem and reviewing all the code. In the "Is there anything you'd like reviewers to focus on?" section, there are real questions I myself did not have definite answers for. Let me know your thoughts.

### What is the purpose of this pull request?

Add an optional feature that tracks physical deletes for models using detached
log placement. When enabled, the `logidze_data` row is preserved after the
origin record is `DELETE`d and a final "deletion" version is appended to
`log_data` capturing _who_ and _when_ via the usual `Logidze.with_responsible`
/ `Logidze.with_meta` helpers.

Prior art: [#61](https://github.com/palkan/logidze/issues/61) raised a similar
idea in 2019 and was declined because Logidze was purely inline at the time and
a separate `logidze_trashes` table was seen as out of scope for a versioning
(not auditing) library. Detached mode (1.4.0, May 2025) changes that premise —
there is already a dedicated `logidze_data` table, and preserving its row
post-`DELETE` is a minimal extension rather than a new subsystem. This PR
leans into that: no new tables, no new models, no new query API — just an
opt-in toggle that drops `dependent: :destroy` and extends the existing
`logidze_logger()` function to handle `TG_OP = 'DELETE'`.

### What changes did you make? (overview)

**Configuration**

- `Logidze.track_deletes` global flag (default `false`).
- `has_logidze detached: true, track_deletes: true` per-model kwarg. Passing
  `track_deletes: true` without detached mode raises `ArgumentError`.
- `rails g logidze:model Post --track-deletes` generator flag. Implies
  `--detached`.

**Runtime / association**

- `has_one :logidze_data` is now declared inside `has_logidze` so its
  `dependent:` option can be toggled per-model. When `track_deletes` is
  enabled, `dependent: :destroy` is omitted so the log survives the record.
- `Logidze::Detachable` keeps only the runtime overrides — the association
  itself moved to `Logidze::HasLogidze`.

**Trigger function**

- `logidze_logger()` bumped to version 6. New `TG_OP = 'DELETE'` branch
  (detached-only): reads the existing `logidze_data` row, appends a new
  version with an empty diff (`c = {}`) and a top-level `_d: true` marker,
  and respects `logidze.disabled` / `logidze.responsible` / `logidze.meta`
  GUCs. Uses `INSERT ... ON CONFLICT DO UPDATE` so it also works when no
  prior log row exists yet. The outer `EXCEPTION WHEN OTHERS` handler
  returns `OLD` when `TG_OP = 'DELETE'` so a captured exception cannot
  silently cancel a delete.
- Model trigger template emits
  `BEFORE INSERT OR UPDATE OR DELETE` when `track_deletes` is enabled
  (both sync and `after` variants).

**Docs**

- New `Tracking deletes` subsection in `README.md` covering setup,
  per-model / global config, snapshot shape, and the id-reuse caveat
  (unique index on `(loggable_type, loggable_id)` means reusing an id on a
  new row will `ON CONFLICT DO UPDATE` and overwrite the deleted log).
- `CHANGELOG.md` entry with an upgrade note
  (`rails g logidze:install --update` to pick up v6 of `logidze_logger`).

### Is there anything you'd like reviewers to focus on?

- **Snapshot shape.** We went with a top-level `_d: true` marker on the
  deletion version (rather than burying it in `_m`) because it's easier to
  query from SQL/JSONB and parallels existing top-level keys (`_v`, `_t`,
  `_r`, `_m`). Happy to move it if you'd prefer.
- **Function versioning.** Bumped `logidze_logger` from v5 → v6 and updated
  both `function_definitions_spec.rb` and `install_generator_spec.rb` to
  match. Existing installs will need `rails g logidze:install --update`.
- **`Detachable` split.** Moving `has_one :logidze_data` into
  `has_logidze` is the smallest change that lets us conditionally drop
  `dependent: :destroy` without adding a second association or
  monkey-patching after the fact. Open to other approaches if this feels
  wrong.
- **Id reuse.** When a new record is later inserted with the same id as a
  deleted one, the existing log is retained and a new full-snapshot version
  is appended on top (previous deletion history is preserved). Called out
  explicitly in the README. Ruby-side query helpers (e.g. a
  `Post.deleted_history` scope) are deliberately not included — the
  existing `logidze_data` schema already supports ad-hoc queries, and
  we wanted to keep this PR minimal. Happy to layer that on if you'd like.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation (Readme)


