### PR TITLE
Skip meta param cleanup when PG transaction is in error state

### DIFF
--- a/lib/logidze/meta.rb
+++ b/lib/logidze/meta.rb
@@ -65,6 +65,18 @@ module Logidze # :nodoc:
           pg_set_meta_param(prev_meta)
         end
       end
+
+      # When a PG transaction enters an error state (e.g., from a constraint
+      # violation), all subsequent SQL commands fail with InFailedSqlTransaction
+      # until the transaction is rolled back. Since SET LOCAL changes are
+      # transaction-scoped, PG automatically reverts them on rollback, so
+      # explicit cleanup is unnecessary and would only raise a secondary error.
+      def transaction_in_error_state?
+        raw_conn = connection.raw_connection
+        raw_conn.transaction_status == PG::PQTRANS_INERROR
+      rescue => _e
+        false
+      end
     end
 
     class MetaWrapper < MetaBase # :nodoc:
@@ -97,7 +109,7 @@ module Logidze # :nodoc:
         result = block.call
         result
       ensure
-        pg_reset_meta_param(prev_meta)
+        pg_reset_meta_param(prev_meta) unless transaction_in_error_state?
         meta_stack.pop
         Thread.current[:logidze_in_block] = was_in_block
       end

--- a/spec/integration/meta_spec.rb
+++ b/spec/integration/meta_spec.rb
@@ -49,6 +49,29 @@ describe "logs metadata", :db do
         expect(subject.reload.meta).to be_nil
       end
 
+      it "handles PG-level error in transaction without raising InFailedSqlTransaction" do
+        # When a PG error (e.g., unique violation) occurs inside with_meta,
+        # the ensure block should skip SET LOCAL cleanup rather than raising
+        # a secondary PG::InFailedSqlTransaction error.
+        expect {
+          Logidze.with_meta(meta) do
+            ActiveRecord::Base.connection.execute("SELECT 1 FROM nonexistent_table_xyz")
+          end
+        }.to raise_error(ActiveRecord::StatementInvalid, /nonexistent_table_xyz/)
+      end
+
+      it "cleans up meta stack after PG-level error" do
+        ignore_exceptions do
+          Logidze.with_meta(meta) do
+            Logidze.with_meta(meta2) do
+              ActiveRecord::Base.connection.execute("SELECT 1 FROM nonexistent_table_xyz")
+            end
+          end
+        end
+
+        expect(Thread.current[:meta]).to eq([])
+      end
+
       it "handles block" do
         block = -> { subject }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

When a PG-level error (e.g., a unique constraint violation) occurs inside a Logidze.with_meta block, the PostgreSQL transaction enters an aborted state. Previously, the ensure block would attempt to run SET LOCAL logidze.meta TO DEFAULT, which would fail with PG::InFailedSqlTransaction, masking the original error.

Since SET LOCAL changes are transaction-scoped, PostgreSQL automatically reverts them when the transaction rolls back. The ensure cleanup is therefore unnecessary (and impossible) when the transaction is in an error state.

### What changes did you make? (overview)

This adds a transaction_in_error_state? check using PG::Connection#transaction_status, which is a stable libpq-level API available across all supported Rails versions (6.0+). The SET LOCAL is skipped if transaction_in_error_state?.

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation (Readme)
